### PR TITLE
Add category to vesuvio calibration algorithms

### DIFF
--- a/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
+++ b/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
@@ -188,6 +188,9 @@ class EVSCalibrationFit(PythonAlgorithm):
   def summary(self):
     return "Fits peaks to a list of spectra using the mass or the d-spacings (for bragg peaks) of the sample."
 
+  def category(self):
+        return "VesuvioCalibration"
+
   def PyInit(self):
 
     self.declareProperty(StringArrayProperty("Samples", Direction.Input),
@@ -892,6 +895,9 @@ class EVSCalibrationAnalysis(PythonAlgorithm):
 
   def summary(self):
     return "Calculates the calibration parameters for the EVS intrument."
+
+  def category(self):
+        return "VesuvioCalibration"
 
   def PyInit(self):
 


### PR DESCRIPTION
**Description of work:**

Adds categories to vesuvio calibration algorithms to prevent warnings being ommited and allow them to be seen in the algorithm widget.

**To test:**

1) Run `calibrate_vesuvio_uranium_martyn_MK5.py` in `mantidplot 3.9.2`. 
2) Observe no warnings ommited
3) Find algorithms in relevant category in algorithm widget

or just code review..

<!-- Instructions for testing. -->

Fixes #35 
