### PR TITLE
Refactor setup and unit test

### DIFF
--- a/unpackaged/vesuvio_calibration/tests/system/test_system.py
+++ b/unpackaged/vesuvio_calibration/tests/system/test_system.py
@@ -371,8 +371,7 @@ class TestEVSCalibrationFit(EVSCalibrationTest):
 
         expected_values = self.calculate_theta_peak_positions()
         params_table = self.run_evs_calibration_fit("Bragg")
-        self.assert_fitted_positions_match_expected(expected_values, params_table,
-                                                    {38: 0.5, 40: 0.49, 41: 0.61, 42: 0.28, 86: 0.44, 162: 0.12, 167: 0.12})
+        self.assert_fitted_positions_match_expected(expected_values, params_table, {15: IGNORE_DETECTOR})
 
     @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.EVSCalibrationFit._load_file')
     def test_fit_bragg_peaks_lead(self, load_file_mock):
@@ -384,7 +383,7 @@ class TestEVSCalibrationFit(EVSCalibrationTest):
 
         expected_values = self.calculate_theta_peak_positions()
         params_table = self.run_evs_calibration_fit("Bragg")
-        self.assert_fitted_positions_match_expected(expected_values, params_table, {156: 0.42, 190: 0.24})
+        self.assert_fitted_positions_match_expected(expected_values, params_table, {145: 0.27, 158: 0.15, 190: IGNORE_DETECTOR})
 
     @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.EVSCalibrationFit._load_file')
     def test_fit_peaks_copper_E1(self, load_file_mock):

--- a/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_fit.py
+++ b/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_fit.py
@@ -1,6 +1,9 @@
-from unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5 import EVSCalibrationFit
+from unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5 import EVSCalibrationFit, DETECTOR_RANGE, \
+     ENERGY_ESTIMATE, BRAGG_PEAK_CROP_RANGE, BRAGG_FIT_WINDOW_RANGE, RECOIL_PEAK_CROP_RANGE, RECOIL_FIT_WINDOW_RANGE, \
+     RESONANCE_PEAK_CROP_RANGE, RESONANCE_FIT_WINDOW_RANGE
 from mock import MagicMock, patch
 from functools import partial
+from mantid.kernel import IntArrayProperty, StringArrayProperty, FloatArrayProperty
 
 import unittest
 import numpy as np
@@ -276,7 +279,6 @@ class TestVesuvioCalibrationFit(unittest.TestCase):
 
         self.assertFalse(alg._check_nans(table_ws))
 
-
     @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
     def test_check_nans_true(self, mock_mtd):
         alg = EVSCalibrationFit()
@@ -292,6 +294,175 @@ class TestVesuvioCalibrationFit(unittest.TestCase):
 
         self.assertTrue(alg._check_nans(table_ws))
 
+    def test_PyInit_property_defaults(self):
+        alg = EVSCalibrationFit()
+        alg.PyInit()
+        properties = {'Samples': [], 'Background': [], 'Mode': 'FoilOut', 'Function': 'Gaussian', 'SpectrumRange': DETECTOR_RANGE,
+                      'Mass': 207.19, 'DSpacings': [], 'Energy': [ENERGY_ESTIMATE], 'InstrumentParameterFile': '',
+                      'PeakType': '', 'InstrumentParameterWorkspace': None, 'CreateOutput': False, 'OutputWorkspace': ''}
+        for prop in properties:
+            expected_value = alg.getProperty(prop).value
+            if type(expected_value) == np.ndarray:
+                expected_value = list(expected_value)
+            self.assertEqual(expected_value, properties[prop], f'Property {prop}. Expected: {expected_value},'
+                                                               f'Actual: {properties[prop]}')
+
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.EVSCalibrationFit._setup_spectra_list')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.EVSCalibrationFit._setup_run_numbers_and_output_workspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.EVSCalibrationFit._setup_function_type')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.EVSCalibrationFit._setup_parameter_workspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.EVSCalibrationFit._setup_peaks_and_set_crop_and_fit_ranges')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.EVSCalibrationFit._setup_class_variables_from_properties')
+    def test_setup_calls_all_functions(self, mock_setup_vars, mock_setup_peaks, mock_setup_param_ws, mock_setup_fn_type,
+                                        mock_setup_run_nos, mock_setup_spec):
+        alg = EVSCalibrationFit()
+        alg._setup()
+        mock_setup_vars.assert_called_once()
+        mock_setup_peaks.assert_called_once()
+        mock_setup_param_ws.assert_called_once()
+        mock_setup_fn_type.assert_called_once()
+        mock_setup_run_nos.assert_called_once()
+        mock_setup_spec.assert_called_once()
+
+    def test_setup_class_variables_from_properties(self):
+        alg = EVSCalibrationFit()
+        alg.PyInit()
+
+        mode = alg.getProperty("Mode").value
+        energy = alg.getProperty("Energy").value
+        mass = alg.getProperty("Mass").value
+        create_output = alg.getProperty("CreateOutput").value
+
+        alg._setup_class_variables_from_properties()
+        self.assertEqual(mode, alg._mode)
+        self.assertEqual(energy, alg._energy_estimates)
+        self.assertEqual(mass, alg._sample_mass)
+        self.assertEqual(create_output, alg._create_output)
+
+    def test_setup_spectra_list(self):
+        test_spec_list = [3, 4, 5, 6]
+        alg = EVSCalibrationFit()
+        alg.declareProperty(IntArrayProperty('SpectrumRange', test_spec_list))
+
+        alg._setup_spectra_list()
+        self.assertEqual([test_spec_list[0], test_spec_list[-1]], alg._spec_list)
+
+    def test_setup_spectra_list_one_spec(self):
+        test_spec_list = [3]
+        alg = EVSCalibrationFit()
+        alg.declareProperty(IntArrayProperty('SpectrumRange', test_spec_list))
+
+        alg._setup_spectra_list()
+        self.assertEqual([test_spec_list[0]], alg._spec_list)
+
+    def test_setup_spectra_list_no_spec(self):
+        test_spec_list = []
+        alg = EVSCalibrationFit()
+        alg.declareProperty(IntArrayProperty('SpectrumRange', test_spec_list))
+        self.assertRaises(ValueError, alg._setup_spectra_list)
+
+    def test_setup_run_numbers_and_output_workspace(self):
+        test_sample_list = [3, 4, 5, 6]
+        test_bg_list = [7, 8, 9, 10]
+        test_ws_name = 'test_ws'
+        alg = EVSCalibrationFit()
+        alg.declareProperty(StringArrayProperty('Samples', test_sample_list))
+        alg.declareProperty(StringArrayProperty('Background', test_bg_list))
+        alg.declareProperty('OutputWorkspace', test_ws_name)
+
+        alg._setup_run_numbers_and_output_workspace()
+        self.assertEqual(str(test_bg_list[0]), alg._background)
+        self.assertEqual(test_ws_name + '_Sample_' + '_'.join([str(x) for x in test_sample_list]), alg._sample)
+
+    def test_setup_run_numbers_and_output_workspace_no_bg(self):
+        test_sample_list = [3, 4, 5, 6]
+        test_bg_list = []
+        test_ws_name = 'test_ws'
+        alg = EVSCalibrationFit()
+        alg.declareProperty(StringArrayProperty('Samples', test_sample_list))
+        alg.declareProperty(StringArrayProperty('Background', test_bg_list))
+        alg.declareProperty('OutputWorkspace', test_ws_name)
+
+        alg._setup_run_numbers_and_output_workspace()
+        self.assertFalse(hasattr(alg, '_background'))
+        self.assertEqual(test_ws_name + '_Sample_' + '_'.join([str(x) for x in test_sample_list]), alg._sample)
+
+    def test_setup_run_numbers_and_output_workspace_no_sample(self):
+        test_sample_list = []
+        test_bg_list = [7, 8, 9, 10]
+        test_ws_name = 'test_ws'
+        alg = EVSCalibrationFit()
+        alg.declareProperty(StringArrayProperty('Samples', test_sample_list))
+        alg.declareProperty(StringArrayProperty('Background', test_bg_list))
+        alg.declareProperty('OutputWorkspace', test_ws_name)
+
+        self.assertRaises(ValueError, alg._setup_run_numbers_and_output_workspace)
+
+    def test_setup_function_type_gaussian(self):
+        alg = EVSCalibrationFit()
+        alg.declareProperty('Function', 'Gaussian')
+        alg._setup_function_type()
+        expected_param_names = {'Height': 'Height', 'Width': 'Sigma', 'Position': 'PeakCentre'}
+        self.assertEqual(expected_param_names, alg._func_param_names)
+        self.assertEqual({k: v+"_Err" for k, v in expected_param_names.items()}, alg._func_param_names_error)
+
+    def test_setup_function_type_voigt(self):
+        alg = EVSCalibrationFit()
+        alg.declareProperty('Function', 'Voigt')
+        alg._setup_function_type()
+        expected_param_names = {'Height': 'LorentzAmp', 'Position': 'LorentzPos', 'Width': 'LorentzFWHM', 'Width_2': 'GaussianFWHM'}
+        self.assertEqual(expected_param_names, alg._func_param_names)
+        self.assertEqual({k: v+"Err" for k, v in expected_param_names.items()}, alg._func_param_names_error)
+
+    def test_setup_function_type_error(self):
+        alg = EVSCalibrationFit()
+        alg.declareProperty('Function', 'Error')
+        self.assertRaises(ValueError, alg._setup_function_type)
+
+    def test_setup_parameter_workspace(self):
+        alg = EVSCalibrationFit()
+        alg.declareProperty('InstrumentParameterWorkspace', 'test_ws')
+        alg.declareProperty('InstrumentParameterFile', '')
+        alg._setup_parameter_workspace()
+        self.assertEqual('test_ws', alg._param_workspace)
+        self.assertEqual('test_ws', alg._param_table)
+
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.load_instrument_parameters')
+    def test_setup_parameter_workspace_no_ws(self, mock_load_instrument_parameters):
+        alg = EVSCalibrationFit()
+        alg.declareProperty('InstrumentParameterWorkspace', '')
+        alg.declareProperty('InstrumentParameterFile', '/c/test_param_dir/file')
+        alg._setup_parameter_workspace()
+        mock_load_instrument_parameters.assert_called_once()
+        self.assertEqual('file', alg._param_table)
+
+    def test_setup_peaks_and_set_crop_and_fit_ranges_bragg(self):
+        test_d_spacings = [3.5, 1.5, 2.5]
+        alg = EVSCalibrationFit()
+        alg.declareProperty(FloatArrayProperty('DSpacings', test_d_spacings))
+        alg.declareProperty('PeakType', 'Bragg')
+        alg._setup_peaks_and_set_crop_and_fit_ranges()
+        self.assertEqual(sorted(test_d_spacings), list(alg._d_spacings))
+        self.assertEqual(BRAGG_PEAK_CROP_RANGE, alg._ws_crop_range)
+        self.assertEqual(BRAGG_FIT_WINDOW_RANGE, alg._fit_window_range)
+
+    def test_setup_peaks_and_set_crop_and_fit_ranges_recoil(self):
+        test_d_spacings = []
+        alg = EVSCalibrationFit()
+        alg.declareProperty(FloatArrayProperty('DSpacings', test_d_spacings))
+        alg.declareProperty('PeakType', 'Recoil')
+        alg._setup_peaks_and_set_crop_and_fit_ranges()
+        self.assertEqual(RECOIL_PEAK_CROP_RANGE, alg._ws_crop_range)
+        self.assertEqual(RECOIL_FIT_WINDOW_RANGE, alg._fit_window_range)
+
+    def test_setup_peaks_and_set_crop_and_fit_ranges_resonance(self):
+        test_d_spacings = []
+        alg = EVSCalibrationFit()
+        alg.declareProperty(FloatArrayProperty('DSpacings', test_d_spacings))
+        alg.declareProperty('PeakType', 'Resonance')
+        alg._setup_peaks_and_set_crop_and_fit_ranges()
+        self.assertEqual(RESONANCE_PEAK_CROP_RANGE, alg._ws_crop_range)
+        self.assertEqual(RESONANCE_FIT_WINDOW_RANGE, alg._fit_window_range)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work:**

Refactors the setup portion of `EVSCalibrationFit`, making it easier to follow and unit test. Add unit tests.

**To test:**
Review code.
Review test changes.
Ensure all automated tests pass.
Ensure the tests in `test_system.py` pass locally (You can run the system tests using `python -m unittest discover -s ./unpackaged/vesuvio_calibration/tests/system` from the root of the repository.) Note that `test_fit_bragg_peaks_copper` and `test_fit_bragg_peaks_lead` are unreliable and fail on different detectors on different PCs. Please post the stack trace if they fail on your machine.


