### PR TITLE
Refactor fit bragg peaks and add unit tests

### DIFF
--- a/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
+++ b/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
@@ -470,9 +470,6 @@ class EVSCalibrationFit(PythonAlgorithm):
                                            'status']
       return fit_results
 
-
-
-
   def _run_find_peaks(self, workspace_index, find_peaks_output_name, find_peaks_input_params, unconstrained):
       try:
           FindPeaks(InputWorkspace=self._sample, WorkspaceIndex=workspace_index, PeaksList=find_peaks_output_name,

--- a/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
+++ b/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
@@ -385,7 +385,7 @@ class EVSCalibrationFit(PythonAlgorithm):
     self._prog_reporter = Progress(self, 0.0, 1.0, num_spectra)
 
     output_parameters_tbl_name = self._output_workspace_name + '_Peak_Parameters'
-    self._create_output_parameters_table_ws(output_parameters_tbl_name)
+    self._create_output_parameters_table_ws(output_parameters_tbl_name, num_estimated_peaks)
 
     output_workspaces = []
     #LOOP PEAK ESTIMATES FOR EACH SPECTRUM

--- a/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_fit.py
+++ b/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_fit.py
@@ -686,68 +686,70 @@ class TestVesuvioCalibrationFit(unittest.TestCase):
         self.assertFalse(result)
 
     @staticmethod
-    def _setup_filter_and_fit_found_peaks_mocks(unconstrained, filter_found_peaks_called=True):
-        instance = EVSCalibrationFit()
+    def _setup_filter_and_fit_found_peaks_mocks():
+        alg = EVSCalibrationFit()
         workspace_index = 0
         peak_estimates_list = 'peak_estimates_list'
         find_peaks_output_name = 'find_peaks_output'
         fit_peaks_output_name = 'fit_peaks_output'
         x_range = (1, 2)
 
-        if unconstrained:
-            instance._calc_linear_bg_coefficients = MagicMock(return_value='linear_bg_coeffs')
-        if filter_found_peaks_called:
-            instance._filter_found_peaks = MagicMock()
-        instance._fit_found_peaks = MagicMock(return_value={'status': 'some_status'})
-        instance._check_fitted_peak_validity = MagicMock(return_value=True)
+        alg._calc_linear_bg_coefficients = MagicMock(return_value='linear_bg_coeffs')
+        alg._filter_found_peaks = MagicMock()
+        alg._fit_found_peaks = MagicMock(return_value={'status': 'test_status'})
+        alg._check_fitted_peak_validity = MagicMock(return_value=True)
 
-        return instance, workspace_index, peak_estimates_list, find_peaks_output_name, fit_peaks_output_name, x_range
+        return alg, workspace_index, peak_estimates_list, find_peaks_output_name, fit_peaks_output_name, x_range
 
     def test_filter_and_fit_found_peaks_unconstrained(self):
-        instance, workspace_index, peak_estimates_list, find_peaks_output_name, fit_peaks_output_name, x_range = self._setup_filter_and_fit_found_peaks_mocks(
-            unconstrained=True)
+        alg, workspace_index, peak_estimates_list, find_peaks_output_name, fit_peaks_output_name,\
+            x_range = self._setup_filter_and_fit_found_peaks_mocks()
 
-        fit_results = instance._filter_and_fit_found_peaks(workspace_index, peak_estimates_list, find_peaks_output_name,
+        fit_results = alg._filter_and_fit_found_peaks(workspace_index, peak_estimates_list, find_peaks_output_name,
                                                            fit_peaks_output_name, x_range, unconstrained=True)
 
-        instance._calc_linear_bg_coefficients.assert_called_once()
-        instance._filter_found_peaks.assert_called_once_with(find_peaks_output_name, peak_estimates_list,
+        alg._calc_linear_bg_coefficients.assert_called_once()
+        alg._filter_found_peaks.assert_called_once_with(find_peaks_output_name, peak_estimates_list,
                                                              'linear_bg_coeffs',
                                                              peak_height_rel_threshold=PEAK_HEIGHT_RELATIVE_THRESHOLD)
-        instance._fit_found_peaks.assert_called_once_with(find_peaks_output_name, None, workspace_index,
+        alg._fit_found_peaks.assert_called_once_with(find_peaks_output_name, None, workspace_index,
                                                           fit_peaks_output_name, x_range)
-        instance._check_fitted_peak_validity.assert_called_once_with(fit_peaks_output_name + '_Parameters',
+        alg._check_fitted_peak_validity.assert_called_once_with(fit_peaks_output_name + '_Parameters',
                                                                      peak_estimates_list,
                                                                      peak_height_rel_threshold=PEAK_HEIGHT_RELATIVE_THRESHOLD)
-        self.assertEqual(fit_results['status'], 'some_status')
+        self.assertEqual(fit_results['status'], 'test_status')
 
 
     def test_filter_and_fit_found_peaks_not_unconstrained(self):
-        instance, workspace_index, peak_estimates_list, find_peaks_output_name, fit_peaks_output_name, x_range = self._setup_filter_and_fit_found_peaks_mocks(
-            unconstrained=False, filter_found_peaks_called=False)
+        alg, workspace_index, peak_estimates_list, find_peaks_output_name, fit_peaks_output_name,\
+            x_range = self._setup_filter_and_fit_found_peaks_mocks()
 
-        fit_results = instance._filter_and_fit_found_peaks(workspace_index, peak_estimates_list, find_peaks_output_name,
+        fit_results = alg._filter_and_fit_found_peaks(workspace_index, peak_estimates_list, find_peaks_output_name,
                                                            fit_peaks_output_name, x_range, unconstrained=False)
 
-        instance._calc_linear_bg_coefficients.assert_not_called()
-        instance._filter_found_peaks.assert_not_called()
-        instance._fit_found_peaks.assert_called_once_with(find_peaks_output_name, peak_estimates_list, workspace_index,
+        alg._calc_linear_bg_coefficients.assert_not_called()
+        alg._filter_found_peaks.assert_not_called()
+        alg._fit_found_peaks.assert_called_once_with(find_peaks_output_name, peak_estimates_list, workspace_index,
                                                           fit_peaks_output_name, x_range)
-        instance._check_fitted_peak_validity.assert_called_once_with(fit_peaks_output_name + '_Parameters',
+        alg._check_fitted_peak_validity.assert_called_once_with(fit_peaks_output_name + '_Parameters',
                                                                      peak_estimates_list,
                                                                      peak_height_rel_threshold=PEAK_HEIGHT_RELATIVE_THRESHOLD)
-        self.assertEqual(fit_results['status'], 'some_status')
+        self.assertEqual(fit_results['status'], 'test_status')
 
     def test_filter_and_fit_found_peaks_invalid_peaks(self):
-        instance, workspace_index, peak_estimates_list, find_peaks_output_name, fit_peaks_output_name, x_range = self._setup_filter_and_fit_found_peaks_mocks(unconstrained=False, filter_found_peaks_called=False)
-        instance._check_fitted_peak_validity.return_value = False
+        alg, workspace_index, peak_estimates_list, find_peaks_output_name, fit_peaks_output_name,\
+            x_range = self._setup_filter_and_fit_found_peaks_mocks()
+        alg._check_fitted_peak_validity.return_value = False
 
-        fit_results = instance._filter_and_fit_found_peaks(workspace_index, peak_estimates_list, find_peaks_output_name, fit_peaks_output_name, x_range, unconstrained=False)
+        fit_results = alg._filter_and_fit_found_peaks(workspace_index, peak_estimates_list, find_peaks_output_name,
+                                                           fit_peaks_output_name, x_range, unconstrained=False)
 
-        instance._calc_linear_bg_coefficients.assert_not_called()
-        instance._filter_found_peaks.assert_not_called()
-        instance._fit_found_peaks.assert_called_once_with(find_peaks_output_name, peak_estimates_list, workspace_index, fit_peaks_output_name, x_range)
-        instance._check_fitted_peak_validity.assert_called_once_with(fit_peaks_output_name + '_Parameters', peak_estimates_list, peak_height_rel_threshold=PEAK_HEIGHT_RELATIVE_THRESHOLD)
+        alg._calc_linear_bg_coefficients.assert_not_called()
+        alg._filter_found_peaks.assert_not_called()
+        alg._fit_found_peaks.assert_called_once_with(find_peaks_output_name, peak_estimates_list, workspace_index,
+                                                          fit_peaks_output_name, x_range)
+        alg._check_fitted_peak_validity.assert_called_once_with(fit_peaks_output_name + '_Parameters',
+                                                                     peak_estimates_list, peak_height_rel_threshold=PEAK_HEIGHT_RELATIVE_THRESHOLD)
         self.assertEqual(fit_results['status'], 'peaks invalid')
 
 

--- a/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_fit.py
+++ b/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_fit.py
@@ -470,17 +470,18 @@ class TestVesuvioCalibrationFit(unittest.TestCase):
         mock_convert_to_dist.assert_called_once_with(output_name, EnableLogging=False)
 
     @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.CreateEmptyTableWorkspace')
-    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd', new_callable=dict)
-    def test_create_output_parameters_table_ws(self, mock_mtd_module, mock_create_empty_table_ws):
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.AnalysisDataService')
+    def test_create_output_parameters_table_ws(self, mock_ADS, mock_create_empty_table_ws):
         output_table_name = 'test_output_table'
         num_estimated_peaks = 3
         alg = EVSCalibrationFit()
         alg._generate_column_headers = MagicMock(return_value=['col1', 'col2', 'col3'])
         mock_output_table = MagicMock()
-        mock_mtd_module[output_table_name] = mock_output_table
+        mock_create_empty_table_ws.return_value = mock_output_table
 
         alg._create_output_parameters_table_ws(output_table_name, num_estimated_peaks)
-        mock_create_empty_table_ws.assert_called_once_with(OutputWorkspace=output_table_name)
+        mock_create_empty_table_ws.assert_called_once()
+        mock_ADS.addOrReplace.assert_called_once_with(output_table_name, mock_output_table)
 
         mock_output_table.addColumn.assert_any_call('int', 'Spectrum')
         for name in ['col1', 'col2', 'col3']:

--- a/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_fit.py
+++ b/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_fit.py
@@ -30,217 +30,270 @@ class TestVesuvioCalibrationFit(unittest.TestCase):
     def side_effect_cell(row_index, col_index, peaks):
         return peaks[row_index]
 
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.DeleteWorkspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.CloneWorkspace')
     @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_filter_peaks_perfect_match(self, mock_mtd):
+    def test_filter_peaks_perfect_match(self, mock_mtd, mock_clone_workspace, mock_del_workspace):
         alg = EVSCalibrationFit()
 
-        peak_table = 'peak_table'
+        find_peaks_output_name = 'find_peaks_output_name'
         peak_estimates_list = [9440, 13351, 15417]
-        return_mock_obj_peak_table = MagicMock()
+        return_mock_find_peaks_output_name_unfiltered = MagicMock()
         found_peaks = [9440, 13351, 15417]
-        return_mock_obj_peak_table.column.return_value = found_peaks
-        return_mock_obj_peak_table.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
+        return_mock_find_peaks_output_name_unfiltered.column.return_value = found_peaks
+        return_mock_find_peaks_output_name_unfiltered.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
 
-        table_to_overwrite = 'overwrite_table'
-        return_mock_obj_overwrite_table = MagicMock()
-        return_mock_obj_overwrite_table.setRowCount = MagicMock()
-        return_mock_obj_overwrite_table.columnCount.return_value = 1
-        return_mock_obj_overwrite_table.rowCount.return_value = len(peak_estimates_list)
-        return_mock_obj_overwrite_table.setCell.side_effect = self.side_effect_set_cell
+        return_mock_find_peaks_output_name = MagicMock()
+        return_mock_find_peaks_output_name.setRowCount = MagicMock()
+        return_mock_find_peaks_output_name.columnCount.return_value = 1
+        return_mock_find_peaks_output_name.rowCount.return_value = len(peak_estimates_list)
+        return_mock_find_peaks_output_name.setCell.side_effect = self.side_effect_set_cell
 
-        mtd_mock_dict = {'peak_table': return_mock_obj_peak_table, 'overwrite_table': return_mock_obj_overwrite_table}
-
-        self.setup_mtd_mock(mock_mtd, mtd_mock_dict)
-
-        linear_bg_coeffs = (0, 0)
-        alg._filter_found_peaks(peak_table, peak_estimates_list, table_to_overwrite, linear_bg_coeffs)
-        self.assertEqual([(0, 0, found_peaks[0]), (1, 0, found_peaks[1]), (2, 0, found_peaks[2])], self.set_cell_list)
-
-    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_filter_peaks_no_match(self, mock_mtd):
-        alg = EVSCalibrationFit()
-
-        peak_table = 'peak_table'
-        peak_estimates_list = [9440, 13351, 15417]
-        return_mock_obj_peak_table = MagicMock()
-        found_peaks = []
-        return_mock_obj_peak_table.column.return_value = found_peaks
-        return_mock_obj_peak_table.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
-        mtd_mock_dict = {'peak_table': return_mock_obj_peak_table}
-
-        table_to_overwrite = 'overwrite_table'
-
-        self.setup_mtd_mock(mock_mtd, mtd_mock_dict)
-
-        linear_bg_coeffs = (0, 0)
-        alg._filter_found_peaks(peak_table, peak_estimates_list, table_to_overwrite, linear_bg_coeffs)
-        self.assertEqual([], self.set_cell_list)
-
-    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_filter_peaks_one_match(self, mock_mtd):
-        alg = EVSCalibrationFit()
-
-        peak_table = 'peak_table'
-        peak_estimates_list = [9440, 13351, 15417]
-        return_mock_obj_peak_table = MagicMock()
-        found_peaks = [13000]
-        return_mock_obj_peak_table.column.return_value = found_peaks
-        return_mock_obj_peak_table.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
-
-        table_to_overwrite = 'overwrite_table'
-        return_mock_obj_overwrite_table = MagicMock()
-        return_mock_obj_overwrite_table.setRowCount = MagicMock()
-        return_mock_obj_overwrite_table.columnCount.return_value = 1
-        return_mock_obj_overwrite_table.rowCount.return_value = len(peak_estimates_list)
-        return_mock_obj_overwrite_table.setCell.side_effect = self.side_effect_set_cell
-
-        mtd_mock_dict = {'peak_table': return_mock_obj_peak_table, 'overwrite_table': return_mock_obj_overwrite_table}
+        mtd_mock_dict = {'find_peaks_output_name': return_mock_find_peaks_output_name,
+                         'find_peaks_output_name_unfiltered': return_mock_find_peaks_output_name_unfiltered}
 
         self.setup_mtd_mock(mock_mtd, mtd_mock_dict)
 
         linear_bg_coeffs = (0, 0)
         alg._func_param_names = {"Position": 'LorentzPos'}
-        alg._filter_found_peaks(peak_table, peak_estimates_list, table_to_overwrite, linear_bg_coeffs)
+        alg._filter_found_peaks(find_peaks_output_name, peak_estimates_list, linear_bg_coeffs)
+        self.assertEqual([(0, 0, found_peaks[0]), (1, 0, found_peaks[1]), (2, 0, found_peaks[2])],
+                         self.set_cell_list)
+        mock_clone_workspace.assert_called_with(InputWorkspace=return_mock_find_peaks_output_name,
+                                                OutputWorkspace=find_peaks_output_name + '_unfiltered')
+        mock_del_workspace.assert_called_with(find_peaks_output_name + '_unfiltered')
+
+
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.DeleteWorkspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.CloneWorkspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
+    def test_filter_peaks_no_match(self, mock_mtd, mock_clone_workspace, mock_del_workspace):
+        alg = EVSCalibrationFit()
+
+        find_peaks_output_name = 'find_peaks_output_name'
+        peak_estimates_list = [9440, 13351, 15417]
+        return_mock_find_peaks_output_name_unfiltered = MagicMock()
+        found_peaks = []
+        return_mock_find_peaks_output_name_unfiltered.column.return_value = found_peaks
+        return_mock_find_peaks_output_name_unfiltered.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
+
+        return_mock_find_peaks_output_name = MagicMock()
+        return_mock_find_peaks_output_name.setRowCount = MagicMock()
+        return_mock_find_peaks_output_name.columnCount.return_value = 1
+        return_mock_find_peaks_output_name.rowCount.return_value = len(peak_estimates_list)
+        return_mock_find_peaks_output_name.setCell.side_effect = self.side_effect_set_cell
+
+        mtd_mock_dict = {'find_peaks_output_name': return_mock_find_peaks_output_name,
+                         'find_peaks_output_name_unfiltered': return_mock_find_peaks_output_name_unfiltered}
+
+        self.setup_mtd_mock(mock_mtd, mtd_mock_dict)
+
+        linear_bg_coeffs = (0, 0)
+        alg._func_param_names = {"Position": 'LorentzPos'}
+        alg._filter_found_peaks(find_peaks_output_name, peak_estimates_list, linear_bg_coeffs)
+        self.assertEqual([], self.set_cell_list)
+        mock_clone_workspace.assert_called_with(InputWorkspace=return_mock_find_peaks_output_name,
+                                                OutputWorkspace=find_peaks_output_name + '_unfiltered')
+        mock_del_workspace.assert_called_with(find_peaks_output_name + '_unfiltered')
+
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.DeleteWorkspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.CloneWorkspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
+    def test_filter_peaks_one_match(self, mock_mtd, mock_clone_workspace, mock_del_workspace):
+        alg = EVSCalibrationFit()
+
+        find_peaks_output_name = 'find_peaks_output_name'
+        peak_estimates_list = [9440, 13351, 15417]
+        return_mock_find_peaks_output_name_unfiltered = MagicMock()
+        found_peaks = [13000]
+        return_mock_find_peaks_output_name_unfiltered.column.return_value = found_peaks
+        return_mock_find_peaks_output_name_unfiltered.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
+
+        return_mock_find_peaks_output_name = MagicMock()
+        return_mock_find_peaks_output_name.setRowCount = MagicMock()
+        return_mock_find_peaks_output_name.columnCount.return_value = 1
+        return_mock_find_peaks_output_name.rowCount.return_value = len(peak_estimates_list)
+        return_mock_find_peaks_output_name.setCell.side_effect = self.side_effect_set_cell
+
+        mtd_mock_dict = {'find_peaks_output_name': return_mock_find_peaks_output_name,
+                         'find_peaks_output_name_unfiltered': return_mock_find_peaks_output_name_unfiltered}
+
+        self.setup_mtd_mock(mock_mtd, mtd_mock_dict)
+
+        linear_bg_coeffs = (0, 0)
+        alg._func_param_names = {"Position": 'LorentzPos'}
+        alg._filter_found_peaks(find_peaks_output_name, peak_estimates_list, linear_bg_coeffs)
         self.assertEqual([('LorentzPos', 0, peak_estimates_list[0]), (1, 0, found_peaks[0]), ('LorentzPos', 2, peak_estimates_list[2])],
                          self.set_cell_list)
+        mock_clone_workspace.assert_called_with(InputWorkspace=return_mock_find_peaks_output_name,
+                                                OutputWorkspace=find_peaks_output_name + '_unfiltered')
+        mock_del_workspace.assert_called_with(find_peaks_output_name + '_unfiltered')
 
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.DeleteWorkspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.CloneWorkspace')
     @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_filter_peaks_two_match(self, mock_mtd):
+    def test_filter_peaks_two_match(self, mock_mtd, mock_clone_workspace, mock_del_workspace):
         alg = EVSCalibrationFit()
 
-        peak_table = 'peak_table'
+        find_peaks_output_name = 'find_peaks_output_name'
         peak_estimates_list = [9440, 13351, 15417]
-        return_mock_obj_peak_table = MagicMock()
+        return_mock_find_peaks_output_name_unfiltered = MagicMock()
         found_peaks = [9000, 16000]
-        return_mock_obj_peak_table.column.return_value = found_peaks
-        return_mock_obj_peak_table.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
+        return_mock_find_peaks_output_name_unfiltered.column.return_value = found_peaks
+        return_mock_find_peaks_output_name_unfiltered.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
 
-        table_to_overwrite = 'overwrite_table'
-        return_mock_obj_overwrite_table = MagicMock()
-        return_mock_obj_overwrite_table.setRowCount = MagicMock()
-        return_mock_obj_overwrite_table.columnCount.return_value = 1
-        return_mock_obj_overwrite_table.rowCount.return_value = len(peak_estimates_list)
-        return_mock_obj_overwrite_table.setCell.side_effect = self.side_effect_set_cell
+        return_mock_find_peaks_output_name = MagicMock()
+        return_mock_find_peaks_output_name.setRowCount = MagicMock()
+        return_mock_find_peaks_output_name.columnCount.return_value = 1
+        return_mock_find_peaks_output_name.rowCount.return_value = len(peak_estimates_list)
+        return_mock_find_peaks_output_name.setCell.side_effect = self.side_effect_set_cell
 
-        mtd_mock_dict = {'peak_table': return_mock_obj_peak_table, 'overwrite_table': return_mock_obj_overwrite_table}
+        mtd_mock_dict = {'find_peaks_output_name': return_mock_find_peaks_output_name,
+                         'find_peaks_output_name_unfiltered': return_mock_find_peaks_output_name_unfiltered}
 
         self.setup_mtd_mock(mock_mtd, mtd_mock_dict)
 
         linear_bg_coeffs = (0, 0)
         alg._func_param_names = {"Position": 'LorentzPos'}
-        alg._filter_found_peaks(peak_table, peak_estimates_list, table_to_overwrite, linear_bg_coeffs)
+        alg._filter_found_peaks(find_peaks_output_name, peak_estimates_list, linear_bg_coeffs)
         self.assertEqual([(0, 0, found_peaks[0]), ('LorentzPos', 1, peak_estimates_list[1]), (2, 0, found_peaks[1])],
                          self.set_cell_list)
+        mock_clone_workspace.assert_called_with(InputWorkspace=return_mock_find_peaks_output_name,
+                                                OutputWorkspace=find_peaks_output_name + '_unfiltered')
+        mock_del_workspace.assert_called_with(find_peaks_output_name + '_unfiltered')
 
+
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.DeleteWorkspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.CloneWorkspace')
     @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_filter_peaks_does_not_include_higher_found_peak(self, mock_mtd):
+    def test_filter_peaks_does_not_include_higher_found_peak(self, mock_mtd, mock_clone_workspace, mock_del_workspace):
         alg = EVSCalibrationFit()
 
-        peak_table = 'peak_table'
+        find_peaks_output_name = 'find_peaks_output_name'
         peak_estimates_list = [9440, 13351, 15417]
-        return_mock_obj_peak_table = MagicMock()
+        return_mock_find_peaks_output_name_unfiltered = MagicMock()
         found_peaks = [9440, 15417, 16000]
-        return_mock_obj_peak_table.column.return_value = found_peaks
-        return_mock_obj_peak_table.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
+        return_mock_find_peaks_output_name_unfiltered.column.return_value = found_peaks
+        return_mock_find_peaks_output_name_unfiltered.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
 
-        table_to_overwrite = 'overwrite_table'
-        return_mock_obj_overwrite_table = MagicMock()
-        return_mock_obj_overwrite_table.setRowCount = MagicMock()
-        return_mock_obj_overwrite_table.columnCount.return_value = 1
-        return_mock_obj_overwrite_table.rowCount.return_value = len(peak_estimates_list)
-        return_mock_obj_overwrite_table.setCell.side_effect = self.side_effect_set_cell
+        return_mock_find_peaks_output_name = MagicMock()
+        return_mock_find_peaks_output_name.setRowCount = MagicMock()
+        return_mock_find_peaks_output_name.columnCount.return_value = 1
+        return_mock_find_peaks_output_name.rowCount.return_value = len(peak_estimates_list)
+        return_mock_find_peaks_output_name.setCell.side_effect = self.side_effect_set_cell
 
-        mtd_mock_dict = {'peak_table': return_mock_obj_peak_table, 'overwrite_table': return_mock_obj_overwrite_table}
+        mtd_mock_dict = {'find_peaks_output_name': return_mock_find_peaks_output_name,
+                         'find_peaks_output_name_unfiltered': return_mock_find_peaks_output_name_unfiltered}
 
         self.setup_mtd_mock(mock_mtd, mtd_mock_dict)
 
         linear_bg_coeffs = (0, 0)
         alg._func_param_names = {"Position": 'LorentzPos'}
-        alg._filter_found_peaks(peak_table, peak_estimates_list, table_to_overwrite, linear_bg_coeffs)
+        alg._filter_found_peaks(find_peaks_output_name, peak_estimates_list, linear_bg_coeffs)
         self.assertEqual([(0, 0, found_peaks[0]), ('LorentzPos', 1, peak_estimates_list[1]), (2, 0, found_peaks[1])],
                          self.set_cell_list)
+        mock_clone_workspace.assert_called_with(InputWorkspace=return_mock_find_peaks_output_name,
+                                                OutputWorkspace=find_peaks_output_name + '_unfiltered')
+        mock_del_workspace.assert_called_with(find_peaks_output_name + '_unfiltered')
 
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.DeleteWorkspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.CloneWorkspace')
     @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_filter_peaks_does_not_include_lower_found_peak(self, mock_mtd):
+    def test_filter_peaks_does_not_include_lower_found_peak(self, mock_mtd, mock_clone_workspace, mock_del_workspace):
         alg = EVSCalibrationFit()
 
-        peak_table = 'peak_table'
+        find_peaks_output_name = 'find_peaks_output_name'
         peak_estimates_list = [9440, 13351, 15417]
-        return_mock_obj_peak_table = MagicMock()
+        return_mock_find_peaks_output_name_unfiltered = MagicMock()
         found_peaks = [8000, 9440, 15417]
-        return_mock_obj_peak_table.column.return_value = found_peaks
-        return_mock_obj_peak_table.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
+        return_mock_find_peaks_output_name_unfiltered.column.return_value = found_peaks
+        return_mock_find_peaks_output_name_unfiltered.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
 
-        table_to_overwrite = 'overwrite_table'
-        return_mock_obj_overwrite_table = MagicMock()
-        return_mock_obj_overwrite_table.setRowCount = MagicMock()
-        return_mock_obj_overwrite_table.columnCount.return_value = 1
-        return_mock_obj_overwrite_table.rowCount.return_value = len(peak_estimates_list)
-        return_mock_obj_overwrite_table.setCell.side_effect = self.side_effect_set_cell
+        return_mock_find_peaks_output_name = MagicMock()
+        return_mock_find_peaks_output_name.setRowCount = MagicMock()
+        return_mock_find_peaks_output_name.columnCount.return_value = 1
+        return_mock_find_peaks_output_name.rowCount.return_value = len(peak_estimates_list)
+        return_mock_find_peaks_output_name.setCell.side_effect = self.side_effect_set_cell
 
-        mtd_mock_dict = {'peak_table': return_mock_obj_peak_table, 'overwrite_table': return_mock_obj_overwrite_table}
+        mtd_mock_dict = {'find_peaks_output_name': return_mock_find_peaks_output_name,
+                         'find_peaks_output_name_unfiltered': return_mock_find_peaks_output_name_unfiltered}
 
         self.setup_mtd_mock(mock_mtd, mtd_mock_dict)
 
         linear_bg_coeffs = (0, 0)
         alg._func_param_names = {"Position": 'LorentzPos'}
-        alg._filter_found_peaks(peak_table, peak_estimates_list, table_to_overwrite, linear_bg_coeffs)
+        alg._filter_found_peaks(find_peaks_output_name, peak_estimates_list, linear_bg_coeffs)
         self.assertEqual([(0, 0, found_peaks[1]), ('LorentzPos', 1, peak_estimates_list[1]), (2, 0, found_peaks[2])],
                          self.set_cell_list)
+        mock_clone_workspace.assert_called_with(InputWorkspace=return_mock_find_peaks_output_name,
+                                                OutputWorkspace=find_peaks_output_name + '_unfiltered')
+        mock_del_workspace.assert_called_with(find_peaks_output_name + '_unfiltered')
 
+
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.DeleteWorkspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.CloneWorkspace')
     @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_filter_peaks_handles_multiple_peaks(self, mock_mtd):
+    def test_filter_peaks_handles_multiple_peaks(self, mock_mtd, mock_clone_workspace, mock_del_workspace):
         alg = EVSCalibrationFit()
 
-        peak_table = 'peak_table'
+        find_peaks_output_name = 'find_peaks_output_name'
         peak_estimates_list = [9440, 13351, 15417]
-        return_mock_obj_peak_table = MagicMock()
+        return_mock_find_peaks_output_name_unfiltered = MagicMock()
         found_peaks = [8000, 9445, 13000, 13355, 15415, 16000]
-        return_mock_obj_peak_table.column.return_value = found_peaks
-        return_mock_obj_peak_table.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
+        return_mock_find_peaks_output_name_unfiltered.column.return_value = found_peaks
+        return_mock_find_peaks_output_name_unfiltered.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
 
-        table_to_overwrite = 'overwrite_table'
-        return_mock_obj_overwrite_table = MagicMock()
-        return_mock_obj_overwrite_table.setRowCount = MagicMock()
-        return_mock_obj_overwrite_table.columnCount.return_value = 1
-        return_mock_obj_overwrite_table.rowCount.return_value = len(peak_estimates_list)
-        return_mock_obj_overwrite_table.setCell.side_effect = self.side_effect_set_cell
+        return_mock_find_peaks_output_name = MagicMock()
+        return_mock_find_peaks_output_name.setRowCount = MagicMock()
+        return_mock_find_peaks_output_name.columnCount.return_value = 1
+        return_mock_find_peaks_output_name.rowCount.return_value = len(peak_estimates_list)
+        return_mock_find_peaks_output_name.setCell.side_effect = self.side_effect_set_cell
 
-        mtd_mock_dict = {'peak_table': return_mock_obj_peak_table, 'overwrite_table': return_mock_obj_overwrite_table}
-
-        self.setup_mtd_mock(mock_mtd, mtd_mock_dict)
-
-        linear_bg_coeffs = (0, 0)
-        alg._filter_found_peaks(peak_table, peak_estimates_list, table_to_overwrite, linear_bg_coeffs)
-        self.assertEqual([(0, 0, found_peaks[1]), (1, 0, found_peaks[3]), (2, 0, found_peaks[4])], self.set_cell_list)
-
-    #Found peaks sometimes returns 'zero' peaks, usually at the end of the table workspace.
-    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_filter_peaks_handles_zero_position_in_found_peaks(self, mock_mtd):
-        alg = EVSCalibrationFit()
-
-        peak_table = 'peak_table'
-        peak_estimates_list = [9440, 13351, 15417]
-        return_mock_obj_peak_table = MagicMock()
-        found_peaks = [9440, 13351, 0]
-        return_mock_obj_peak_table.column.return_value = found_peaks
-        return_mock_obj_peak_table.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
-
-        table_to_overwrite = 'overwrite_table'
-        return_mock_obj_overwrite_table = MagicMock()
-        return_mock_obj_overwrite_table.setRowCount = MagicMock()
-        return_mock_obj_overwrite_table.columnCount.return_value = 1
-        return_mock_obj_overwrite_table.rowCount.return_value = len(peak_estimates_list)
-        return_mock_obj_overwrite_table.setCell.side_effect = self.side_effect_set_cell
-
-        mtd_mock_dict = {'peak_table': return_mock_obj_peak_table, 'overwrite_table': return_mock_obj_overwrite_table}
+        mtd_mock_dict = {'find_peaks_output_name': return_mock_find_peaks_output_name,
+                         'find_peaks_output_name_unfiltered': return_mock_find_peaks_output_name_unfiltered}
 
         self.setup_mtd_mock(mock_mtd, mtd_mock_dict)
 
         linear_bg_coeffs = (0, 0)
         alg._func_param_names = {"Position": 'LorentzPos'}
-        alg._filter_found_peaks(peak_table, peak_estimates_list, table_to_overwrite, linear_bg_coeffs)
+        alg._filter_found_peaks(find_peaks_output_name, peak_estimates_list, linear_bg_coeffs)
+        self.assertEqual([(0, 0, found_peaks[1]), (1, 0, found_peaks[3]), (2, 0, found_peaks[4])], self.set_cell_list)
+        mock_clone_workspace.assert_called_with(InputWorkspace=return_mock_find_peaks_output_name,
+                                                OutputWorkspace=find_peaks_output_name + '_unfiltered')
+        mock_del_workspace.assert_called_with(find_peaks_output_name + '_unfiltered')
+
+    #Found peaks sometimes returns 'zero' peaks, usually at the end of the table workspace.
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.DeleteWorkspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.CloneWorkspace')
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
+    def test_filter_peaks_handles_zero_position_in_found_peaks(self, mock_mtd, mock_clone_workspace, mock_del_workspace):
+        alg = EVSCalibrationFit()
+
+        find_peaks_output_name = 'find_peaks_output_name'
+        peak_estimates_list = [9440, 13351, 15417]
+        return_mock_find_peaks_output_name_unfiltered = MagicMock()
+        found_peaks = [9440, 13351, 0]
+        return_mock_find_peaks_output_name_unfiltered.column.return_value = found_peaks
+        return_mock_find_peaks_output_name_unfiltered.cell.side_effect = partial(self.side_effect_cell, peaks=found_peaks)
+
+        return_mock_find_peaks_output_name = MagicMock()
+        return_mock_find_peaks_output_name.setRowCount = MagicMock()
+        return_mock_find_peaks_output_name.columnCount.return_value = 1
+        return_mock_find_peaks_output_name.rowCount.return_value = len(peak_estimates_list)
+        return_mock_find_peaks_output_name.setCell.side_effect = self.side_effect_set_cell
+
+        mtd_mock_dict = {'find_peaks_output_name': return_mock_find_peaks_output_name,
+                         'find_peaks_output_name_unfiltered': return_mock_find_peaks_output_name_unfiltered}
+
+        self.setup_mtd_mock(mock_mtd, mtd_mock_dict)
+
+        linear_bg_coeffs = (0, 0)
+        alg._func_param_names = {"Position": 'LorentzPos'}
+        alg._filter_found_peaks(find_peaks_output_name, peak_estimates_list, linear_bg_coeffs)
         self.assertEqual([(0, 0, found_peaks[0]), (1, 0, found_peaks[1]), ('LorentzPos', 2, peak_estimates_list[2])], self.set_cell_list)
+        mock_clone_workspace.assert_called_with(InputWorkspace=return_mock_find_peaks_output_name,
+                                                OutputWorkspace=find_peaks_output_name + '_unfiltered')
+        mock_del_workspace.assert_called_with(find_peaks_output_name + '_unfiltered')
 
     def test_estimate_bragg_peak_positions(self):
         def side_effect(arg1, arg2):


### PR DESCRIPTION
**Description of work:**

Refactors the `_fit_bragg_peaks` portion of `EVSCalibrationFit`, making it easier to follow and unit test. This was probably the most convoluted function.

Unit tests have been added where the code has been refactored.

**To test:**
Review code.
Review test changes.
Ensure all automated tests pass.
Ensure the tests in `test_system.py` pass locally (You can run the system tests using `python -m unittest discover -s ./unpackaged/vesuvio_calibration/tests/system` from the root of the repository.) Note that `test_fit_bragg_peaks_copper` and `test_fit_bragg_peaks_lead` are unreliable and fail on different detectors on different PCs. Please post the stack trace if they fail on your machine.

