### PR TITLE
Refactor fit peaks

### DIFF
--- a/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
+++ b/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
@@ -671,7 +671,7 @@ class EVSCalibrationFit(PythonAlgorithm):
     estimated_peak_positions_all_spec = self._estimate_peak_positions()
     num_estimated_peaks, num_spectra = estimated_peak_positions_all_spec.shape
 
-    self._prog_reporter = Progress(self, 0.0, 1.0, *num_spectra)
+    self._prog_reporter = Progress(self, 0.0, 1.0, num_spectra)
 
     self._output_parameter_tables = []
     self._peak_fit_workspaces_by_spec = []
@@ -679,7 +679,7 @@ class EVSCalibrationFit(PythonAlgorithm):
 
       self._peak_fit_workspaces = []
       for peak_index, peak_position in enumerate(estimated_peak_positions):
-        output_parameter_table_name, fit_workspace_name = self.fit_peak(spec_index, peak_index, peak_position)
+        fit_workspace_name, output_parameter_table_name = self._fit_peak(spec_index, peak_index, peak_position)
         self._output_parameter_tables.append(output_parameter_table_name)
         self._peak_fit_workspaces.append(fit_workspace_name)
 


### PR DESCRIPTION
**Description of work:**

Refactors the `_fit_peaks` portion of `EVSCalibrationFit`, making it easier to follow and unit test. 

Unit tests have been added where the code has been refactored.

**To test:**
Review code.
Review test changes.
Ensure all automated tests pass.
Ensure the tests in `test_system.py` pass locally (You can run the system tests using `python -m unittest discover -s ./unpackaged/vesuvio_calibration/tests/system` from the root of the repository.) Note that `test_fit_bragg_peaks_copper` and `test_fit_bragg_peaks_lead` are unreliable and fail on different detectors on different PCs. Please post the stack trace if they fail on your machine.