### PR TITLE
Add ability to globally fit a shared parameter

### DIFF
--- a/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
+++ b/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
@@ -138,7 +138,6 @@ def identify_invalid_spectra(peak_table, peak_centres, peak_centres_errors, spec
 
   return invalid_spectra
 
-
 #----------------------------------------------------------------------------------------
 # The IP text file load function skips the first 3 rows of the text file.
 # This assumes that there is one line for the file header and 2 lines for
@@ -288,7 +287,7 @@ class EVSCalibrationFit(PythonAlgorithm):
 
     shared_fit_type_validator = StringListValidator(["Individual", "Shared", "Both"])
     self.declareProperty('SharedParameterFitType', "Individual", doc='Calculate shared parameters using an individual and/or'
-                                                              'global fit.', validator=shared_fit_type_validator)
+                         'global fit.', validator=shared_fit_type_validator)
 
     self.declareProperty(ITableWorkspaceProperty("InstrumentParameterWorkspace", "", Direction.Input, PropertyMode.Optional),
       doc='Workspace contain instrument parameters.')
@@ -1365,7 +1364,7 @@ class EVSCalibrationAnalysis(PythonAlgorithm):
 
     shared_fit_type_validator = StringListValidator(["Individual", "Shared", "Both"])
     self.declareProperty('SharedParameterFitType', "Individual", doc='Calculate shared parameters using an individual and/or'
-                                                              'global fit.', validator=shared_fit_type_validator)
+                         'global fit.', validator=shared_fit_type_validator)
 
     self.declareProperty('CreateOutput', False,
       doc="Whether to create output from fitting.")
@@ -1584,38 +1583,6 @@ class EVSCalibrationAnalysis(PythonAlgorithm):
 
     self._set_table_column(self._current_workspace, 'L1', L1, spec_list)
     self._set_table_column(self._current_workspace, 'L1_Err', L1_error, spec_list)
-
-#----------------------------------------------------------------------------------------
-
-  def _identify_invalid_spectra(self, peak_table, peak_centres, peak_centres_errors, spec_list):
-    """
-      Inspect fitting results, and identify the fits associated with invalid spectra. These are spectra associated with detectors
-      which have lost foil coverage following a recent reduction in distance from source to detectors.
-
-      @param peak_table - name of table containing fitted parameters each spectra.
-      @param peak_centres - a list of the found peak centres
-      @param peak_centres_errors - a list of errors associated with the peak centres
-      @param spec_list - spectrum range to inspect.
-      @return a list of invalid spectra.
-    """
-    peak_Gaussian_FWHM = read_fitting_result_table_column(peak_table, 'f1.GaussianFWHM', spec_list)
-    peak_Gaussian_FWHM_errors = read_fitting_result_table_column(peak_table, 'f1.GaussianFWHM_Err', spec_list)
-    peak_Lorentz_FWHM = read_fitting_result_table_column(peak_table, 'f1.LorentzFWHM', spec_list)
-    peak_Lorentz_FWHM_errors = read_fitting_result_table_column(peak_table, 'f1.LorentzFWHM_Err', spec_list)
-    peak_Lorentz_Amp = read_fitting_result_table_column(peak_table, 'f1.LorentzAmp', spec_list)
-    peak_Lorentz_Amp_errors = read_fitting_result_table_column(peak_table, 'f1.LorentzAmp_Err', spec_list)
-
-    invalid_spectra = np.argwhere((np.isinf(peak_Lorentz_Amp_errors)) | (np.isnan(peak_Lorentz_Amp_errors))  | \
-    (np.isinf(peak_centres_errors)) | (np.isnan(peak_centres_errors))  | \
-    (np.isnan(peak_Gaussian_FWHM_errors)) | (np.isinf(peak_Gaussian_FWHM_errors)) | \
-    (np.isnan(peak_Lorentz_FWHM_errors)) | (np.isinf(peak_Lorentz_FWHM_errors)) | \
-    (np.isnan(peak_Lorentz_Amp_errors)) | (np.isinf(peak_Lorentz_Amp_errors)) | \
-    (np.absolute(peak_Gaussian_FWHM_errors) > np.absolute(peak_Gaussian_FWHM)) | \
-    (np.absolute(peak_Lorentz_FWHM_errors) > np.absolute(peak_Lorentz_FWHM)) | \
-    (np.absolute(peak_Lorentz_Amp_errors) > np.absolute(peak_Lorentz_Amp)) | \
-    (np.absolute(peak_centres_errors) > np.absolute(peak_centres)))
-
-    return invalid_spectra
 
  # ----------------------------------------------------------------------------------------
 

--- a/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
+++ b/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
@@ -431,7 +431,7 @@ class EVSCalibrationFit(PythonAlgorithm):
       return ws_name + '_unconstrained'
 
   def _create_output_parameters_table_ws(self, output_table_name, num_estimated_peaks):
-    table = CreateEmptyTableWorkspace()
+    table = CreateEmptyTableWorkspace(OutputWorkspace=output_table_name)
 
     col_headers = self._generate_column_headers(num_estimated_peaks)
 

--- a/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
+++ b/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
@@ -295,7 +295,7 @@ class EVSCalibrationFit(PythonAlgorithm):
     self.declareProperty('OutputWorkspace', '', StringMandatoryValidator(),
       doc="Name to call the output workspace.")
       
-    self.declareProperty('CalculateSharedParameter', False, doc='Calculate shared parameter across all detectors')
+    self.declareProperty('GlobalFitSharedParameter', False, doc='Perform a global fit to calculate shared parameter across all detectors')
 
 #----------------------------------------------------------------------------------------
 
@@ -334,7 +334,7 @@ class EVSCalibrationFit(PythonAlgorithm):
     self._energy_estimates = self.getProperty("Energy").value
     self._sample_mass = self.getProperty("Mass").value
     self._create_output = self.getProperty("CreateOutput").value
-    self._calculate_shared_parameter = self.getProperty("CalculateSharedParameter").value
+    self._global_fit_shared_parameter = self.getProperty("GlobalFitSharedParameter").value
 
   def _setup_spectra_list(self):
     self._spec_list = self.getProperty("SpectrumRange").value.tolist()
@@ -790,7 +790,7 @@ class EVSCalibrationFit(PythonAlgorithm):
 
     GroupWorkspaces(self._output_parameter_tables, OutputWorkspace=self._output_workspace_name + '_Peak_Parameters')
 
-    if self._calculate_shared_parameter == True:
+    if self._global_fit_shared_parameter == True:
         init_Gaussian_FWHM = read_fitting_result_table_column(output_parameter_table_name, 'f1.GaussianFWHM', self._spec_list)
         init_Gaussian_FWHM = np.nanmean(init_Gaussian_FWHM[init_Gaussian_FWHM != 0])
         init_Lorentz_FWHM = read_fitting_result_table_column(output_parameter_table_name, 'f1.LorentzFWHM', self._spec_list)
@@ -1429,7 +1429,7 @@ class EVSCalibrationAnalysis(PythonAlgorithm):
       E1_fit_back = self._current_workspace + '_E1_back'
       self._run_calibration_fit(Samples=self._samples, Function='Voigt', Mode='SingleDifference', SpectrumRange=BACKSCATTERING_RANGE,
                                 InstrumentParameterWorkspace=self._param_table, Mass=self._sample_mass, OutputWorkspace=E1_fit_back, CreateOutput=self._create_output,
-                                PeakType='Recoil', CalculateSharedParameter=True)
+                                PeakType='Recoil', GlobalFitSharedParameter=False)
       
       E1_peak_fits_back = mtd[self._current_workspace + '_E1_back_Peak_Parameters'].getNames()
       self._calculate_final_energy(E1_peak_fits_back, BACKSCATTERING_RANGE)
@@ -1441,7 +1441,7 @@ class EVSCalibrationAnalysis(PythonAlgorithm):
       E1_fit_front = self._current_workspace + '_E1_front'
       self._run_calibration_fit(Samples=self._samples, Function='Voigt', Mode='SingleDifference', SpectrumRange=FRONTSCATTERING_RANGE,
                                 InstrumentParameterWorkspace=self._param_table, Mass=self._sample_mass, OutputWorkspace=E1_fit_front, CreateOutput=self._create_output,
-                                PeakType='Recoil', CalculateSharedParameter=True)
+                                PeakType='Recoil', GlobalFitSharedParameter=False)
       
       E1_peak_fits_front = mtd[self._current_workspace + '_E1_front_Peak_Parameters'].getNames()
       self._calculate_final_flight_path(E1_peak_fits_front[0], FRONTSCATTERING_RANGE)

--- a/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
+++ b/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
@@ -1432,10 +1432,10 @@ class EVSCalibrationAnalysis(PythonAlgorithm):
                                 PeakType='Recoil', CalculateSharedParameter=True)
       
       E1_peak_fits_back = mtd[self._current_workspace + '_E1_back_Peak_Parameters'].getNames()
-      self._calculate_final_energy(E1_peak_fits_back[0], BACKSCATTERING_RANGE)
+      self._calculate_final_energy(E1_peak_fits_back, BACKSCATTERING_RANGE)
       
       # calibrate L1 for backscattering detectors based on the averaged E1 value  and calibrated theta values 
-      self._calculate_final_flight_path(E1_peak_fits_back, BACKSCATTERING_RANGE)
+      self._calculate_final_flight_path(E1_peak_fits_back[0], BACKSCATTERING_RANGE)
       
       # calibrate L1 for frontscattering detectors based on the averaged E1 value  and calibrated theta values 
       E1_fit_front = self._current_workspace + '_E1_front'
@@ -1679,7 +1679,6 @@ class EVSCalibrationAnalysis(PythonAlgorithm):
 
         peak_centres = read_fitting_result_table_column(peak_table[0], 'f1.LorentzPos', spec_list)
         peak_centres_errors = read_fitting_result_table_column(peak_table[0], 'f1.LorentzPos_Err', spec_list)
-
 
         invalid_spectra = identify_invalid_spectra(peak_table[0], peak_centres, peak_centres_errors, spec_list)
         peak_centres[invalid_spectra] = np.nan

--- a/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
+++ b/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
@@ -26,7 +26,6 @@ import sys
 import scipy.constants
 import scipy.stats
 import numpy as np
-import time
 
 # Configuration for Uranium runs / Indium runs
 #----------------------------------------------------------------------------------------

--- a/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
+++ b/unpackaged/vesuvio_calibration/calibrate_vesuvio_uranium_martyn_MK5.py
@@ -458,8 +458,9 @@ class EVSCalibrationFit(PythonAlgorithm):
         self._output_params_to_table(spec_number, num_estimated_peaks, selected_params, output_parameters_tbl_name)
 
         output_workspaces.append(
-            self._get_output_and_clean_workspaces(fit_results_unconstrained is not None, fit_results_unconstrained is not False, unconstrained_fit_selected, find_peaks_output_name,
-                                                  fit_peaks_output_name))
+            self._get_output_and_clean_workspaces(fit_results_unconstrained is not None,
+                                                  (fit_results_unconstrained is not None and fit_results_unconstrained is not False),
+                                                  unconstrained_fit_selected, find_peaks_output_name, fit_peaks_output_name))
 
     if self._create_output:
         GroupWorkspaces(','.join(output_workspaces), OutputWorkspace=self._output_workspace_name + "_Peak_Fits")
@@ -783,8 +784,8 @@ class EVSCalibrationFit(PythonAlgorithm):
       output_parameter_table_name = self._output_workspace_name + '_Peak_%d_Parameters' % peak_index
       output_parameter_table_headers = self._create_parameter_table_and_output_headers(output_parameter_table_name)
       for spec_index, peak_position in enumerate(estimated_peak_positions):
-        fit_workspace_name, x_range = self._fit_peak(peak_index, spec_index, peak_position, output_parameter_table_name,
-                                                     output_parameter_table_headers)
+        fit_workspace_name = self._fit_peak(peak_index, spec_index, peak_position, output_parameter_table_name,
+                                            output_parameter_table_headers)
         self._peak_fit_workspaces_by_spec.append(fit_workspace_name)
 
       self._output_parameter_tables.append(output_parameter_table_name)
@@ -831,7 +832,7 @@ class EVSCalibrationFit(PythonAlgorithm):
     fit_workspace_name = fws.name()
     self._del_fit_workspaces(ncm, fit_params, fws)
 
-    return fit_workspace_name, (xmin, xmax)
+    return fit_workspace_name
 
   def _find_peaks_and_output_params(self, peak_index, spec_number, spec_index, peak_position):
     peak_table_name = '__' + self._sample + '_peaks_table_%d_%d' % (peak_index, spec_index)

--- a/unpackaged/vesuvio_calibration/tests/system/test_system.py
+++ b/unpackaged/vesuvio_calibration/tests/system/test_system.py
@@ -319,6 +319,23 @@ class TestEVSCalibrationAnalysis(EVSCalibrationTest):
                                                                              165, 167, 168, 169, 170, 182, 191, 192]})
         self.assert_parameters_match_expected(params_table, detector_specific_r_tols)
 
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.EVSCalibrationFit._load_file')
+    def test_copper_create_output(self, load_file_mock):
+        self._setup_copper_test()
+        self._output_workspace = "copper_analysis_test"
+
+        load_file_mock.side_effect = self._load_file_side_effect
+
+        self.create_evs_calibration_alg()
+        self._alg.setProperty("CreateOutput", True)
+        params_table = self.execute_evs_calibration_analysis()
+
+        #  Specify detectors tolerances set by user, then update with those to mask as invalid.
+        detector_specific_r_tols = {"L1": {116: 0.65, 170: 0.75}}
+        detector_specific_r_tols["L1"].update({k: INVALID_DETECTOR for k in [138, 141, 146, 147, 156, 158, 160, 163, 164,
+                                                                             165, 167, 168, 169, 170, 182, 191, 192]})
+        self.assert_parameters_match_expected(params_table, detector_specific_r_tols)
+
     def tearDown(self):
         mtd.clear()
 

--- a/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_analysis.py
+++ b/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_analysis.py
@@ -1,8 +1,6 @@
 from unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5 import EVSCalibrationAnalysis
-from mock import MagicMock, patch
 
 import unittest
-import numpy as np
 
 
 class TestVesuvioCalibrationAnalysis(unittest.TestCase):
@@ -13,56 +11,8 @@ class TestVesuvioCalibrationAnalysis(unittest.TestCase):
     def setUp(self):
         pass
 
-    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_identify_invalid_spectra_no_invalid(self, mock_mtd):
-        alg = EVSCalibrationAnalysis()
-        ws_mock = MagicMock()
-        mock_column_output_dict = {'f1.GaussianFWHM': [1, 2, 3], 'f1.GaussianFWHM_Err': [0.1, 0.2, 0.3],
-                                   'f1.LorentzFWHM': [1.1, 2.1, 3.1], 'f1.LorentzFWHM_Err': [0.11, 0.21, 0.31],
-                                   'f1.LorentzAmp': [1.2, 2.2, 3.2], 'f1.LorentzAmp_Err': [0.12, 0.22, 0.32]}
-        ws_mock.column.side_effect = lambda key: mock_column_output_dict[key]
-        mock_mtd.__getitem__.return_value = ws_mock
-
-        np.testing.assert_equal(np.argwhere([]), alg._identify_invalid_spectra('peak_table', [5, 10, 20], [0.1, 0.15, 0.2], [0, 2]))
-
-    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_identify_invalid_spectra_nan_in_errors(self, mock_mtd):
-        alg = EVSCalibrationAnalysis()
-        ws_mock = MagicMock()
-        mock_column_output_dict = {'f1.GaussianFWHM': [1, 2, 3], 'f1.GaussianFWHM_Err': [np.nan, 0.2, 0.3],
-                                   'f1.LorentzFWHM': [1.1, 2.1, 3.1], 'f1.LorentzFWHM_Err': [0.11, 0.21, 0.31],
-                                   'f1.LorentzAmp': [1.2, 2.2, 3.2], 'f1.LorentzAmp_Err': [0.12, 0.22, np.nan]}
-        ws_mock.column.side_effect = lambda key: mock_column_output_dict[key]
-        mock_mtd.__getitem__.return_value = ws_mock
-
-        np.testing.assert_equal(np.argwhere(np.array([True, False, True])),
-                                alg._identify_invalid_spectra('peak_table', [5, 10, 20], [0.1, 0.15, 0.2], [0, 2]))
-
-    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_identify_invalid_spectra_inf_in_errors(self, mock_mtd):
-        alg = EVSCalibrationAnalysis()
-        ws_mock = MagicMock()
-        mock_column_output_dict = {'f1.GaussianFWHM': [1, 2, 3], 'f1.GaussianFWHM_Err': [0.1, 0.2, 0.3],
-                                   'f1.LorentzFWHM': [1.1, 2.1, 3.1], 'f1.LorentzFWHM_Err': [np.inf, 0.21, 0.31],
-                                   'f1.LorentzAmp': [1.2, 2.2, 3.2], 'f1.LorentzAmp_Err': [0.12, np.inf, 0.32]}
-        ws_mock.column.side_effect = lambda key: mock_column_output_dict[key]
-        mock_mtd.__getitem__.return_value = ws_mock
-
-        np.testing.assert_equal(np.argwhere(np.array([True, True, False])),
-                                alg._identify_invalid_spectra('peak_table', [5, 10, 20], [0.1, 0.15, 0.2], [0, 2]))
-
-    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
-    def test_identify_invalid_spectra_error_greater_than_peak(self, mock_mtd):
-        alg = EVSCalibrationAnalysis()
-        ws_mock = MagicMock()
-        mock_column_output_dict = {'f1.GaussianFWHM': [1, 2, 3], 'f1.GaussianFWHM_Err': [0.1, 0.2, 0.3],
-                                   'f1.LorentzFWHM': [1.1, 2.1, 3.1], 'f1.LorentzFWHM_Err': [0.11, 10, 0.31],
-                                   'f1.LorentzAmp': [1.2, 2.2, 3.2], 'f1.LorentzAmp_Err': [0.12, 0.22, 10]}
-        ws_mock.column.side_effect = lambda key: mock_column_output_dict[key]
-        mock_mtd.__getitem__.return_value = ws_mock
-
-        np.testing.assert_equal(np.argwhere(np.array([False, True, True])),
-                                alg._identify_invalid_spectra('peak_table', [5, 10, 20], [0.1, 0.15, 0.2], [0, 2]))
+    def test_placeholder(self):
+        pass
 
 
 if __name__ == '__main__':

--- a/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_misc.py
+++ b/unpackaged/vesuvio_calibration/tests/unit/test_calibrate_vesuvio_misc.py
@@ -1,7 +1,8 @@
-from unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5 import generate_fit_function_header
+from unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5 import generate_fit_function_header, identify_invalid_spectra
 from mock import MagicMock, patch
 
 import unittest
+import numpy as np
 
 
 class TestVesuvioCalibrationMisc(unittest.TestCase):
@@ -32,6 +33,53 @@ class TestVesuvioCalibrationMisc(unittest.TestCase):
     def test_generate_header_function_invalid(self):
         with self.assertRaises(ValueError):
             generate_fit_function_header("Invalid")
+
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
+    def test_identify_invalid_spectra_no_invalid(self, mock_mtd):
+        ws_mock = MagicMock()
+        mock_column_output_dict = {'f1.GaussianFWHM': [1, 2, 3], 'f1.GaussianFWHM_Err': [0.1, 0.2, 0.3],
+                                   'f1.LorentzFWHM': [1.1, 2.1, 3.1], 'f1.LorentzFWHM_Err': [0.11, 0.21, 0.31],
+                                   'f1.LorentzAmp': [1.2, 2.2, 3.2], 'f1.LorentzAmp_Err': [0.12, 0.22, 0.32]}
+        ws_mock.column.side_effect = lambda key: mock_column_output_dict[key]
+        mock_mtd.__getitem__.return_value = ws_mock
+
+        np.testing.assert_equal(np.argwhere([]), identify_invalid_spectra('peak_table', [5, 10, 20], [0.1, 0.15, 0.2], [0, 2]))
+
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
+    def test_identify_invalid_spectra_nan_in_errors(self, mock_mtd):
+        ws_mock = MagicMock()
+        mock_column_output_dict = {'f1.GaussianFWHM': [1, 2, 3], 'f1.GaussianFWHM_Err': [np.nan, 0.2, 0.3],
+                                   'f1.LorentzFWHM': [1.1, 2.1, 3.1], 'f1.LorentzFWHM_Err': [0.11, 0.21, 0.31],
+                                   'f1.LorentzAmp': [1.2, 2.2, 3.2], 'f1.LorentzAmp_Err': [0.12, 0.22, np.nan]}
+        ws_mock.column.side_effect = lambda key: mock_column_output_dict[key]
+        mock_mtd.__getitem__.return_value = ws_mock
+
+        np.testing.assert_equal(np.argwhere(np.array([True, False, True])),
+                                identify_invalid_spectra('peak_table', [5, 10, 20], [0.1, 0.15, 0.2], [0, 2]))
+
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
+    def test_identify_invalid_spectra_inf_in_errors(self, mock_mtd):
+        ws_mock = MagicMock()
+        mock_column_output_dict = {'f1.GaussianFWHM': [1, 2, 3], 'f1.GaussianFWHM_Err': [0.1, 0.2, 0.3],
+                                   'f1.LorentzFWHM': [1.1, 2.1, 3.1], 'f1.LorentzFWHM_Err': [np.inf, 0.21, 0.31],
+                                   'f1.LorentzAmp': [1.2, 2.2, 3.2], 'f1.LorentzAmp_Err': [0.12, np.inf, 0.32]}
+        ws_mock.column.side_effect = lambda key: mock_column_output_dict[key]
+        mock_mtd.__getitem__.return_value = ws_mock
+
+        np.testing.assert_equal(np.argwhere(np.array([True, True, False])),
+                                identify_invalid_spectra('peak_table', [5, 10, 20], [0.1, 0.15, 0.2], [0, 2]))
+
+    @patch('unpackaged.vesuvio_calibration.calibrate_vesuvio_uranium_martyn_MK5.mtd')
+    def test_identify_invalid_spectra_error_greater_than_peak(self, mock_mtd):
+        ws_mock = MagicMock()
+        mock_column_output_dict = {'f1.GaussianFWHM': [1, 2, 3], 'f1.GaussianFWHM_Err': [0.1, 0.2, 0.3],
+                                   'f1.LorentzFWHM': [1.1, 2.1, 3.1], 'f1.LorentzFWHM_Err': [0.11, 10, 0.31],
+                                   'f1.LorentzAmp': [1.2, 2.2, 3.2], 'f1.LorentzAmp_Err': [0.12, 0.22, 10]}
+        ws_mock.column.side_effect = lambda key: mock_column_output_dict[key]
+        mock_mtd.__getitem__.return_value = ws_mock
+
+        np.testing.assert_equal(np.argwhere(np.array([False, True, True])),
+                                identify_invalid_spectra('peak_table', [5, 10, 20], [0.1, 0.15, 0.2], [0, 2]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work:**

This PR contains work that @jess-farmer has done in order to enable the global fitting of shared parameters.

In addition to this, I have added a system test and slightly refactored some of the code.

**To test:**

1. Ensure system tests pass (note that the new global fitting takes quite a while to run).
2. Ensure unit tests pass
3. Load the algorithms into `mantid`, ensure the new drop down menus to select `SharedParameterFitType` work.

This PR leaves a number of issues: #59

"Code quality" is not a priority, this code will be refactored and improved where necessary in a subsequent PR (see above issue).

This PR resolves: #60
