### PR TITLE
Check ws metadata before locally loading workspace

### DIFF
--- a/EVSVesuvio/config/analysis_inputs.py
+++ b/EVSVesuvio/config/analysis_inputs.py
@@ -7,7 +7,6 @@ class LoadVesuvioBackParameters:
 
     runs="43066-43076"         # 77K         # The numbers of the runs to be analysed
     empty_runs="41876-41923"   # 77K         # The numbers of the empty runs to be subtracted
-    spectra='3-134'                          # Spectra to be analysed
     mode='DoubleDifference'
 
     subEmptyFromRaw = True         # Flag to control wether empty ws gets subtracted from raw
@@ -21,7 +20,6 @@ class LoadVesuvioFrontParameters:
 
     runs='43066-43076'         # 100K        # The numbers of the runs to be analysed
     empty_runs='43868-43911'   # 100K        # The numbers of the empty runs to be subtracted
-    spectra='144-182'                        # Spectra to be analysed
     mode='SingleDifference'
 
     subEmptyFromRaw = False         # Flag to control wether empty ws gets subtracted from raw


### PR DESCRIPTION
**Description of work:**
Introduced a check for the history of workspaces saved locally, so that the loaded workspaces always match the inputs.

**To test:**
- Create a new experiment
- Run the default analysis inputs
- The workspaces will be loaded using LoadVesuvio
- When the user input is required, type `y`
- The script should be running as usual
- Cancel the running script with a keyboard interrupt
- Open `analysis_inputs.py` and change ipfile from `ip2018_3.par` to `ip2019.par` in the LoadVesuvioBackParameters class
- Open mantidworkbench
- open script `analysis_runner.py` on the mantid script editor
- Edit script to call `run()`
- This will start running the analysis routine 
- The new workspace should be loaded from LoadVesuvio i.e. from the data archive
- Left click on the `_BACKWARD_raw.nxs` -> Show History -> click on LoadVesuvio:
- 
![image](https://github.com/mantidproject/vesuvio/assets/80104863/c8fc8e8e-9eed-405f-86d8-e53d6c058ba5)
- Check that `InstrumentParFile` was called with `ip2019.par` file.

Fixes #69 .
