### PR TITLE
Change mantid pin to a minimum verison and fix python pin

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -24,7 +24,7 @@ requirements:
 
   run:
     - python {{ python }}
-    - mantid==6.7.0
+    - mantid
     - matplotlib
     - iminuit
     - h5py

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -24,7 +24,7 @@ requirements:
 
   run:
     - python {{ python }}
-    - mantid
+    - mantid>=6.7
     - matplotlib
     - iminuit
     - h5py

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - mantid
 
 dependencies:
-  - python==3.8 #Upgrade to python 3.10
+  - python==3.8.* #Upgrade to python 3.10
   - flake8
   - conda-wrappers
   - pre-commit==2.15 #review this

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - conda-wrappers
   - pre-commit==2.15 #review this
   - coverage
-  - mantid
+  - mantid>=6.7
   - matplotlib
   - iminuit
   - h5py


### PR DESCRIPTION
**Description of work:**

Adds back in mantid pin, but with a minimum version.

Fix python pin to allow all 3.8 minor versions as intended.