### PR TITLE
Publish nightly to pypi

### DIFF
--- a/.github/actions/publish-conda-package/action.yml
+++ b/.github/actions/publish-conda-package/action.yml
@@ -22,7 +22,7 @@ runs:
     shell: bash -l {0}
     run: |
       conda config --set always_yes yes --set changeps1 no
-      conda create -n build-env python=3.8.*
+      conda create -n build-env python=3.10.*
       conda activate build-env
       mamba install -c conda-forge mamba conda-build anaconda-client conda-verify
       conda config --add channels mantid

--- a/.github/actions/publish-pypi-package/action.yml
+++ b/.github/actions/publish-pypi-package/action.yml
@@ -1,0 +1,26 @@
+name: Build and upload pypi package
+
+inputs:
+  token:
+    description: 'PyPI API Token'
+    required: true
+
+description: Build and upload pypi package
+runs:
+  using: "composite"
+
+  steps:
+  - name: Make build-env-pypi
+    shell: bash -l {0}
+    run: |
+      conda config --set always_yes yes --set changeps1 no
+      conda create -n build-env-pypi python=3.10.*
+      conda activate build-env-pypi
+      mamba install -c conda-forge python-build twine 
+
+  - name: Build package
+    shell: bash -l {0}
+    run: |
+      conda activate build-env-pypi
+      python -m build
+      twine upload -r testpypi -u __token__ -p ${{ inputs.token }} dist/*

--- a/.github/actions/publish-pypi-package/action.yml
+++ b/.github/actions/publish-pypi-package/action.yml
@@ -23,4 +23,4 @@ runs:
     run: |
       conda activate build-env-pypi
       python -m build
-      twine upload -r testpypi -u __token__ -p ${{ inputs.token }} dist/*
+      twine upload -u __token__ -p ${{ inputs.token }} dist/*

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -1,11 +1,11 @@
 name: Deploy mvesuvio nightly
 
-on: push
-  # workflow_run:
-  #   workflows: ["mvesuvio nightly build"]
-  #   branches: [main]
-  #   types:
-  #     - completed
+on:
+  workflow_run:
+    workflows: ["mvesuvio nightly build"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   build_conda_and_upload:
@@ -19,14 +19,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: publish-nighly-pypi 
-          # ref: main
+          ref: main
 
       - name: Check for changes since last build
         run: |
           echo "recentCommits=$(test -z $(git log --since="yesterday" -1 --format=%h) && echo false || echo true)" >> $GITHUB_ENV
       - name: Setup Miniconda
-        # if: ${{ env.recentCommits == 'true'}}
+        if: ${{ env.recentCommits == 'true'}}
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
@@ -36,14 +35,14 @@ jobs:
           auto-activate-base: false
 
       - name: Build mvesuvio nightly conda package
-        # if: ${{ env.recentCommits == 'true'}}
+        if: ${{ env.recentCommits == 'true'}}
         uses: ./.github/actions/publish-conda-package
         with:
           label: nightly
           token: ${{ secrets.ANACONDA_API_TOKEN }}
 
       - name: Build mvesuvio nightly PyPI package
-        # if: ${{ env.recentCommits == 'true'}}
+        if: ${{ env.recentCommits == 'true'}}
         uses: ./.github/actions/publish-pypi-package
         with:
           token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -46,4 +46,4 @@ jobs:
         # if: ${{ env.recentCommits == 'true'}}
         uses: ./.github/actions/publish-pypi-package
         with:
-          token: ${{ secrets.PYPI_TOKEN }}
+          token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -1,11 +1,11 @@
 name: Deploy mvesuvio nightly
 
-on:
-  workflow_run:
-    workflows: ["mvesuvio nightly build"]
-    branches: [main]
-    types:
-      - completed
+on: push
+  # workflow_run:
+  #   workflows: ["mvesuvio nightly build"]
+  #   branches: [main]
+  #   types:
+  #     - completed
 
 jobs:
   build_conda_and_upload:
@@ -19,13 +19,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: main
+          ref: publish-nighly-pypi 
+          # ref: main
 
       - name: Check for changes since last build
         run: |
           echo "recentCommits=$(test -z $(git log --since="yesterday" -1 --format=%h) && echo false || echo true)" >> $GITHUB_ENV
       - name: Setup Miniconda
-        if: ${{ env.recentCommits == 'true'}}
+        # if: ${{ env.recentCommits == 'true'}}
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
@@ -35,8 +36,14 @@ jobs:
           auto-activate-base: false
 
       - name: Build mvesuvio nightly conda package
-        if: ${{ env.recentCommits == 'true'}}
-        uses: ./.github/actions/publish-package
+        # if: ${{ env.recentCommits == 'true'}}
+        uses: ./.github/actions/publish-conda-package
         with:
           label: nightly
           token: ${{ secrets.ANACONDA_API_TOKEN }}
+
+      - name: Build mvesuvio nightly PyPI package
+        # if: ${{ env.recentCommits == 'true'}}
+        uses: ./.github/actions/publish-pypi-package
+        with:
+          token: ${{ secrets.PYPI_TOKEN }}

--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -1,5 +1,5 @@
 python:
-  - 3.8
+  - 3.10
 
 jacobi:
   - 0.4.2 #pinned until later versions are proven.

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - conda-wrappers
   - pre-commit==2.15 #review this
   - coverage
-  - mantid>=6.7
+  - mantid==6.8
   - matplotlib
   - iminuit
   - h5py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = "Analyse Vesuvio instrument data"
 readme = "README.md"
-requires-python = "==3.10.*"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,8 @@ method = "minor"
 
 [tool.versioningit.format]
 distance = "{version}.dev{distance}"
-dirty = "{version}+uncommitted"
-distance-dirty = "{version}.dev{distance}+uncommitted"
+dirty = "{version}.dev{distance}"
+distance-dirty = "{version}.dev{distance}"
 
 [tool.versioningit.write]
 file = "mvesuvio/_version.py"


### PR DESCRIPTION
**Description of work:**
The main sentiment expressed by Matthew in #104 was that the use of the terminal should be as minimal as possible. With the changes to the CLI the part of using the terminal to create experiments is avoided but there was still another part of the problem missing. Namely the necessity of still having to activate a conda environment on the terminal every time an user wants to use mantid with the mvesuvio repository. Ideally Matthew doesn't touch the terminal on his daily use of the package.

The solution I came up with is to publish the package to PyPI nightly as we are currently doing with conda.
The reasons for this are the following:
- If an user has a standalone installation of mantid, then can install the latest version of mvesuvio by navigating to the directory with the mantid python executable and doing `./python -m pip install mvesuvio`
- If the user wants to use a conda installation, then they can install mvesuvio from conda as before

The advantages of this approach is that users install mvesuvio only one time per mantid installation, using a single command. The disadvantage is of course that the CLI is not accessible via this installation. This will not be a problem due to the changes I have implemented in https://github.com/mantidproject/vesuvio/pull/105. These changes effectively mean that the user uses the default IP folder directory as **the** directory on their machine to store IP files. This is not a huge compromise as this directory is not meant to be changed anyway.

**To test:**
I will merge this to main (I know, I know) and check whether the nightly builds were successful :cowboy_hat_face: 
