### PR TITLE
Add FSE correction on each spectra before focusing all spectra

### DIFF
--- a/mvesuvio/config/analysis_inputs.py
+++ b/mvesuvio/config/analysis_inputs.py
@@ -139,7 +139,8 @@ class ForwardInitialConditions(GeneralInitialConditions):
 
 class YSpaceFitInitialConditions:
     showPlots = True
-    symmetrisationFlag = True
+    subtractFSE = True
+    symmetrisationFlag = False 
     rebinParametersForYSpaceFit = "-25, 0.5, 25"  # Needs to be symetric
     fitModel = "SINGLE_GAUSSIAN"  # Options: 'SINGLE_GAUSSIAN', 'GC_C4', 'GC_C6', 'GC_C4_C6', 'DOUBLE_WELL', 'ANSIO_GAUSSIAN', 'Gaussian3D'
     runMinos = True

--- a/mvesuvio/system_tests/test_config/expr_for_tests.py
+++ b/mvesuvio/system_tests/test_config/expr_for_tests.py
@@ -108,6 +108,7 @@ class ForwardInitialConditions(GeneralInitialConditions):
 
 class YSpaceFitInitialConditions:
     showPlots = False
+    subtractFSE = False
     symmetrisationFlag = True
     rebinParametersForYSpaceFit = "-20, 0.5, 20"  # Needs to be symetric
     fitModel = "SINGLE_GAUSSIAN"

--- a/mvesuvio/vesuvio_analysis/fit_in_yspace.py
+++ b/mvesuvio/vesuvio_analysis/fit_in_yspace.py
@@ -18,6 +18,9 @@ def fitInYSpaceProcedure(yFitIC, IC, wsTOF):
 
     wsTOFMass0 = subtractAllMassesExceptFirst(IC, wsTOF, ncpForEachMass)
 
+    if yFitIC.subtractFSE:
+        wsTOFMass0 = Minus(wsTOFMass0, wsTOF.name() + "_TOF_FSE_0", OutputWorkspace=wsTOFMass0.name() + "_FSE")
+
     wsJoY, wsJoYAvg = ySpaceReduction(
         wsTOFMass0, IC.masses[0], yFitIC, ncpForEachMass[:, 0, :]
     )


### PR DESCRIPTION
The idea behind this change is that subtracting FSE is more physically correct and symmetrasion of the profile should be no longer necessary or deprecated.

**Description of work:**
During the fitting of NCP to each spectra, store the FSE corrections on workspaces.
During the data processing part before focusing data for y sapce fit, use the stored fse on the workspaces and subtract only the fse for the first mass from the isolated first mass for all spectra (before doing the weighted average).

It's not necessary to subtract the FSE for the other masses because this is done already when we subtract the ncp fits (since strictly speaknig the ncp fits include the FSE corrections i.e. NCP+FSE)

**To test:**

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Part of the work in #113 
