### PR TITLE
Select analysis or calibration tests according to changes

### DIFF
--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -33,21 +33,25 @@ jobs:
 
       # Runs Unit tests
       - name: Run mvesuvio Analysis Unit Tests
+        if: "contains(github.event.pull_request.changed_files, 'src/mvesuvio/**')"
         run: |
           export MANTIDPROPERTIES=$(pwd)/Mantid.user.properties
           python -m unittest discover -s ./tests/analysis/unit
 
       # Runs System tests
       - name: Run mvesuvio Analysis System Tests
+        if: "contains(github.event.pull_request.changed_files, 'src/mvesuvio/**')"
         run: |
           python -m unittest discover -s ./tests/analysis/system
 
       - name: Run mvesuvio Calibration Unit Tests
+        if: "contains(github.event.pull_request.changed_files, 'tools/calibration_scripts/**')"
         run: |
           export MANTIDPROPERTIES=$(pwd)/Mantid.user.properties
           python -m unittest discover -s ./tests/calibration/unit
 
       - name: Run Vesuvio Calibration System Tests
+        if: "contains(github.event.pull_request.changed_files, 'tools/calibration_scripts/**')"
         run: |
           python -m unittest discover -s ./tests/calibration/system
 

--- a/src/mvesuvio/config/analysis_inputs.py
+++ b/src/mvesuvio/config/analysis_inputs.py
@@ -2,8 +2,7 @@ import numpy as np
 
 
 class LoadVesuvioBackParameters:
-    def __init__(self, ipFilesPath):
-        self.ipfile = ipFilesPath / "ip2019.par"
+    ipfile = "ip2019.par"
 
     runs = "43066-43076"  # 77K         # The numbers of the runs to be analysed
     empty_runs = (
@@ -17,8 +16,7 @@ class LoadVesuvioBackParameters:
 
 
 class LoadVesuvioFrontParameters:
-    def __init__(self, ipFilesPath):
-        self.ipfile = ipFilesPath / "ip2018_3.par"
+    ipfile = "ip2018_3.par"
 
     runs = "43066-43076"  # 100K        # The numbers of the runs to be analysed
     empty_runs = (
@@ -39,8 +37,7 @@ class GeneralInitialConditions:
 
 
 class BackwardInitialConditions(GeneralInitialConditions):
-    def __init__(self, ipFilesPath):
-        self.InstrParsPath = ipFilesPath / "ip2018_3.par"
+    ipfile = "ip2018_3.par"
 
     HToMassIdxRatio = 19.0620008206  # Set to zero or None when H is not present
     massIdx = 0

--- a/src/mvesuvio/main/analysis_runner.py
+++ b/src/mvesuvio/main/analysis_runner.py
@@ -14,9 +14,13 @@ def run(yes_to_all=False):
 
     start_time = time.time()
 
-    wsBackIC = ai.LoadVesuvioBackParameters(ipFilesPath)
-    wsFrontIC = ai.LoadVesuvioFrontParameters(ipFilesPath)
-    bckwdIC = ai.BackwardInitialConditions(ipFilesPath)
+    wsBackIC = ai.LoadVesuvioBackParameters
+    wsBackIC.ipfile = ipFilesPath / wsBackIC.ipfile
+    wsFrontIC = ai.LoadVesuvioFrontParameters
+    wsFrontIC.ipfile = ipFilesPath / wsFrontIC.ipfile
+    bckwdIC = ai.BackwardInitialConditions
+    bckwdIC.InstrParsPath = ipFilesPath / bckwdIC.ipfile 
+
     fwdIC = ai.ForwardInitialConditions
     yFitIC = ai.YSpaceFitInitialConditions
     userCtr = ai.UserScriptControls

--- a/tools/calibration_scripts/calibrate_vesuvio_helper_functions.py
+++ b/tools/calibration_scripts/calibrate_vesuvio_helper_functions.py
@@ -1,6 +1,5 @@
 import numpy as np
 import scipy.constants
-
 from mantid.simpleapi import CreateEmptyTableWorkspace, mtd
 
 


### PR DESCRIPTION
**Description of work:**

Added four if statements that check for changes in the location of the analysis scripts or the calibration scripts.

The reasoning is to only run analysis unit tests if the analysis scripts were changes and to run the calibration tests if the calibration scripts were changed.


**To test:**

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #90 .
