### PR TITLE
Change github workflow to choose which tests to run

### DIFF
--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest 
     defaults:
       run:
         shell: bash -l {0}
@@ -16,7 +16,7 @@ jobs:
 
       # Set up conda environnment
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge
@@ -27,27 +27,37 @@ jobs:
       - name: Flake8
         run: python -m flake8 --config=config.flake8
 
-      # Remove `export MANTIDPROPERTIES=$(pwd)/Mantid.user.properties` when updated to mantid > 6.8.0
+      - name: Install Git 
+        run: mamba install -y git
+
       - name: Install mvesuvio package
         run: pip install .
 
-      # Runs Unit tests
-      - name: Run mvesuvio Analysis Unit Tests
+      - name: Check for analysis files changed 
         run: |
-          export MANTIDPROPERTIES=$(pwd)/Mantid.user.properties
+          echo "analysis-changed=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q '^src/' && echo true || echo false)" >> $GITHUB_ENV
+
+      - name: Check for calibration files changed 
+        run: |
+          echo "calibration-changed=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q '^tools/calibration_scripts/' && echo true || echo false)" >> $GITHUB_ENV
+
+      - name: Run mvesuvio Analysis Unit Tests
+        if: ${{ env.analysis-changed == 'true'}}
+        run: |
           python -m unittest discover -s ./tests/analysis/unit
 
-      # Runs System tests
       - name: Run mvesuvio Analysis System Tests
+        if: ${{ env.analysis-changed == 'true'}}
         run: |
           python -m unittest discover -s ./tests/analysis/system
 
       - name: Run mvesuvio Calibration Unit Tests
+        if: ${{ env.calibration-changed == 'true'}}
         run: |
-          export MANTIDPROPERTIES=$(pwd)/Mantid.user.properties
           python -m unittest discover -s ./tests/calibration/unit
 
       - name: Run Vesuvio Calibration System Tests
+        if: ${{ env.calibration-changed == 'true'}}
         run: |
           python -m unittest discover -s ./tests/calibration/system
 

--- a/src/mvesuvio/analysis_reduction.py
+++ b/src/mvesuvio/analysis_reduction.py
@@ -2,7 +2,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from mantid.simpleapi import *
 from scipy import optimize
-
 from .analysis_fitting import passDataIntoWS, replaceZerosWithNCP
 
 # Format print output of arrays

--- a/tools/calibration_scripts/calibrate_vesuvio_helper_functions.py
+++ b/tools/calibration_scripts/calibrate_vesuvio_helper_functions.py
@@ -1,6 +1,5 @@
 import numpy as np
 import scipy.constants
-
 from mantid.simpleapi import CreateEmptyTableWorkspace, mtd
 
 


### PR DESCRIPTION
**Description of work:**

There were several changes in this commit:

- The host for running the job changed from self-hosted to ubuntu-latest. This falls in line with the GitHub recommendation to use the default ubuntu-latest for non-private repos. The host was made self-hosted because before the system tests exceeded GitHub's limit. The running time was decreased in a previous commit so using ubuntu-latest is now a viable option.
- Removed some unnecessary comments.
- Added steps that check whether analysis or calibration files were changed using git diff. The result of the check is stored in environment variables analysis-changed and calibration-changed.
- Calibration and analysis tests check the stored environment variables and run accordingly.

**To test:**

Look at the workflow actions and check that:

- No tests were run in the first commit (no changes to analysis or calibration files)
- The Analysis unit and system tests were triggered after changing analysis files
- The Calibration unit and system tests were triggered after changing the calibration files

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #90 .
