### PR TITLE
Add coverage to unit tests

### DIFF
--- a/.github/workflows/ci_tests_nightly.yml
+++ b/.github/workflows/ci_tests_nightly.yml
@@ -1,8 +1,9 @@
 name: mvesuvio nightly build
 
-on:
-  schedule:
-    - cron: '0 2 * * *'
+on: push
+# on:
+#   schedule:
+#     - cron: '0 2 * * *'
 
 jobs:
   test:
@@ -41,7 +42,7 @@ jobs:
         run: |
           coveralls --service=github-actions
 
-      # Runs System tests
-      - name: Run mvesuvio analysis system tests
-        run: |
-          python -m unittest discover -s ./tests/system
+      # # Runs System tests
+      # - name: Run mvesuvio analysis system tests
+      #   run: |
+      #     python -m unittest discover -s ./tests/system

--- a/.github/workflows/ci_tests_nightly.yml
+++ b/.github/workflows/ci_tests_nightly.yml
@@ -1,9 +1,8 @@
 name: mvesuvio nightly build
 
-on: push
-# on:
-#   schedule:
-#     - cron: '0 2 * * *'
+on:
+  schedule:
+    - cron: '0 2 * * *'
 
 jobs:
   test:
@@ -42,7 +41,7 @@ jobs:
         run: |
           coveralls --service=github-actions
 
-      # # Runs System tests
-      # - name: Run mvesuvio analysis system tests
-      #   run: |
-      #     python -m unittest discover -s ./tests/system
+      # Runs System tests
+      - name: Run mvesuvio analysis system tests
+        run: |
+          python -m unittest discover -s ./tests/system

--- a/.github/workflows/ci_tests_nightly.yml
+++ b/.github/workflows/ci_tests_nightly.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest 
     defaults:
       run:
         shell: bash -l {0}
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge
@@ -25,15 +25,23 @@ jobs:
           auto-activate-base: false
 
       - name: Install mvesuvio package
-        run: pip install .
+        # The editable flag is necessary for coverage to find the src/ files
+        run: pip install -e .
 
       # Runs Unit tests
       - name: Run mvesuvio analysis unit tests
         run: |
-          export MANTIDPROPERTIES=$(pwd)/Mantid.user.properties
-          python -m unittest discover -s ./tests/analysis/unit
+          coverage run -m unittest discover -s ./tests/unit
+          coverage report
+
+      # Send coverage report to Coveralls
+      - name: Send coverage report to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN : ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: |
+          coveralls --service=github-actions
 
       # Runs System tests
       - name: Run mvesuvio analysis system tests
         run: |
-          python -m unittest discover -s ./tests/analysis/system
+          python -m unittest discover -s ./tests/system

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -60,7 +60,3 @@ jobs:
         if: ${{ env.calibration-changed == 'true'}}
         run: |
           python -m unittest discover -s ./tests/system/calibration
-
-      # Report coverage
-      #- name: Report Coverage
-      #  run: coverage report

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# VESUVIO REPOSITORY
+# Mantid VESUVIO
+
+[![Coverage Status](https://coveralls.io/repos/github/mantidproject/vesuvio/badge.svg?branch=add-coverage-tests)](https://coveralls.io/github/mantidproject/vesuvio?branch=add-coverage-tests)
 
 This repository contains:
 - `mvesuvio` package containing the Optimized NCP analysis procedures, published nightly.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mantid VESUVIO
 
-[![Coverage Status](https://coveralls.io/repos/github/mantidproject/vesuvio/badge.svg?branch=add-coverage-tests)](https://coveralls.io/github/mantidproject/vesuvio?branch=add-coverage-tests)
+[![Coverage Status](https://coveralls.io/repos/github/mantidproject/vesuvio/badge.svg?branch=main)](https://coveralls.io/github/mantidproject/vesuvio?branch=main)
 
 This repository contains:
 - `mvesuvio` package containing the Optimized NCP analysis procedures, published nightly.

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - flake8
   - conda-wrappers
   - pre-commit==2.15 #review this
-  - coverage
+  - coveralls
   - mantid
   - matplotlib
   - iminuit
@@ -17,3 +17,4 @@ dependencies:
   - mock
   - pytest
   - jacobi==0.4.2 #pinned until newer versions functionality confirmed
+  - coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ pythonpath = [
 testpaths = ["tests"]
 filterwarnings = ["error"]
 
-[tool.coverage.report]
+[tool.coverage.run]
 include = [
     "*/src/mvesuvio/*",
     "*/tools/calibration_scripts/*"
@@ -70,6 +70,7 @@ omit = [
     "*legacy*"
 ]
 
+[tool.coverage.report]
 fail_under = 0
 show_missing = true
 skip_empty = true


### PR DESCRIPTION
**Description of work:**
Add coverage badge and status for unit tests that are run nightly

**To test:**
- Review code on nightly workflow.
- Check that nightly workflow is run successfully on second commit.
- The badge is not working because I changed the branch it points to in the last commit. It was working fine before.
Once the first nightly build from the main branch is run then it should work properly.

Fixes #13 .
