### PR TITLE
Update gamma correction to use updated algorithm

### DIFF
--- a/src/mvesuvio/analysis_reduction.py
+++ b/src/mvesuvio/analysis_reduction.py
@@ -995,24 +995,9 @@ class AnalysisRoutine:
         profiles = self.calcGammaCorrectionProfiles(self._mean_widths, self._mean_intensity_ratios)
 
         # Approach below not currently suitable for current versions of Mantid, but will be in the future
-        # background, corrected = VesuvioCalculateGammaBackground(InputWorkspace=inputWS, ComptonFunction=profiles)
-        # DeleteWorkspace(corrected)
-        # RenameWorkspace(InputWorkspace= background, OutputWorkspace = inputWS+"_Gamma_Background")
-
-        ws = CloneWorkspace(InputWorkspace=inputWS, OutputWorkspace="tmpGC")
-        for spec in range(ws.getNumberHistograms()):
-            background, corrected = VesuvioCalculateGammaBackground(
-                InputWorkspace=inputWS, ComptonFunction=profiles, WorkspaceIndexList=spec
-            )
-            ws.dataY(spec)[:], ws.dataE(spec)[:] = (
-                background.dataY(0)[:],
-                background.dataE(0)[:],
-            )
-        DeleteWorkspace(background)
+        background, corrected = VesuvioCalculateGammaBackground(InputWorkspace=inputWS, ComptonFunction=profiles)
         DeleteWorkspace(corrected)
-        RenameWorkspace(
-            InputWorkspace="tmpGC", OutputWorkspace=inputWS + "_Gamma_Background"
-        )
+        RenameWorkspace(InputWorkspace= background, OutputWorkspace = inputWS + "_Gamma_Background")
 
         Scale(
             InputWorkspace=inputWS + "_Gamma_Background",

--- a/src/mvesuvio/analysis_reduction.py
+++ b/src/mvesuvio/analysis_reduction.py
@@ -994,7 +994,6 @@ class AnalysisRoutine:
 
         profiles = self.calcGammaCorrectionProfiles(self._mean_widths, self._mean_intensity_ratios)
 
-        # Approach below not currently suitable for current versions of Mantid, but will be in the future
         background, corrected = VesuvioCalculateGammaBackground(InputWorkspace=inputWS, ComptonFunction=profiles)
         DeleteWorkspace(corrected)
         RenameWorkspace(InputWorkspace= background, OutputWorkspace = inputWS + "_Gamma_Background")


### PR DESCRIPTION
Mantid's algorithm for gamma correction was recently updated in to correct a bug where output workspaces would not preserve the order of the spectra.

Now that this is fixed, we can avoid using a for loop for the gamma correction algorithm.

**Description of work:**
Uncommented part of code that I had written in the past to be in place once the update went in.

**To test:**
Look at the code and make sure the analysis system tests passed.

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #xxxx.
