### PR TITLE
Update entrypoint in conda install

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,7 +15,7 @@ build:
   noarch: python
   script: python -m pip install --ignore-installed .
   entry_points:
-    - mvesuvio = mvesuvio.scripts:main
+    - mvesuvio = mvesuvio.main:main
 
 requirements:
   build:
@@ -29,6 +29,7 @@ requirements:
     - iminuit
     - h5py
     - jacobi {{ jacobi }}
+    - dill
 
 test:
   imports:


### PR DESCRIPTION
**Description of work:**
Conda install was successful but running any command like `mvesuvio config` would cause an error due to the outdated entrypoint


**To test:**
In the vesuvio repository directory Run the following commands to build the package through conda:

```shell
conda config --set always_yes yes --set changeps1 no
conda create -n build-env python=3.10.*
conda activate build-env
mamba install -c conda-forge mamba conda-build anaconda-client conda-verify
conda config --add channels mantid
conda config --add channels mantid/label/nightly
conda activate build-env
mamba build ./conda
``` 

From the terminal output copy the path where the package was created and run
`mamba install <path-to-zip-file>`

Run `mvesuvio config` and it should not show any errors.
<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->

