### PR TITLE
FSE subtraction

### DIFF
--- a/src/mvesuvio/analysis_reduction.py
+++ b/src/mvesuvio/analysis_reduction.py
@@ -245,8 +245,10 @@ class VesuvioAnalysisRoutine(PythonAlgorithm):
             DataY=np.zeros(self._dataY.size),
             DataE=np.zeros(self._dataE.size),
             Nspec=self._workspace_being_fit.getNumberHistograms(),
+            UnitX="TOF",    # I had hoped for a method like .XUnit() but alas
             OutputWorkspace=self._workspace_being_fit.name()+suffix,
-            ParentWorkspace=self._workspace_being_fit
+            ParentWorkspace=self._workspace_being_fit,
+            Distribution=True
     )
 
 
@@ -667,8 +669,10 @@ class VesuvioAnalysisRoutine(PythonAlgorithm):
             / deltaQ
             * 0.72
         )
-        NCP = intensities * (JOfY + FSE) * E0 * E0 ** (-0.92) * masses / deltaQ
-        return NCP, FSE
+        scaling_factor = intensities * E0 * E0 ** (-0.92) * masses / deltaQ
+        JoY *= scaling_factor
+        FSE *= scaling_factor
+        return JoY+FSE, FSE
 
 
     def caculateResolutionForEachMass(self, centers):

--- a/src/mvesuvio/analysis_reduction.py
+++ b/src/mvesuvio/analysis_reduction.py
@@ -670,9 +670,9 @@ class VesuvioAnalysisRoutine(PythonAlgorithm):
             * 0.72
         )
         scaling_factor = intensities * E0 * E0 ** (-0.92) * masses / deltaQ
-        JoY *= scaling_factor
+        JOfY *= scaling_factor
         FSE *= scaling_factor
-        return JoY+FSE, FSE
+        return JOfY+FSE, FSE
 
 
     def caculateResolutionForEachMass(self, centers):

--- a/src/mvesuvio/config/analysis_inputs.py
+++ b/src/mvesuvio/config/analysis_inputs.py
@@ -86,7 +86,8 @@ class ForwardAnalysisInputs(SampleParameters):
 @dataclass
 class YSpaceFitInputs:
     showPlots = True
-    symmetrisationFlag = True
+    symmetrisationFlag = False
+    subtractFSE = True
     rebinParametersForYSpaceFit = "-25, 0.5, 25"  # Needs to be symetric
     fitModel = "SINGLE_GAUSSIAN"  # Options: 'SINGLE_GAUSSIAN', 'GC_C4', 'GC_C6', 'GC_C4_C6', 'DOUBLE_WELL', 'ANSIO_GAUSSIAN', 'Gaussian3D'
     runMinos = True

--- a/tests/data/analysis/inputs/analysis_test.py
+++ b/tests/data/analysis/inputs/analysis_test.py
@@ -87,6 +87,7 @@ class ForwardAnalysisInputs(SampleParameters):
 class YSpaceFitInputs:
     showPlots = False
     symmetrisationFlag = True
+    subtractFSE = False
     rebinParametersForYSpaceFit = "-20, 0.5, 20"  # Needs to be symetric
     fitModel = "SINGLE_GAUSSIAN"
     runMinos = True


### PR DESCRIPTION
**Description of work:**
Add option to analysis inputs file to subtract FSE corrections to NCP counts before fitting the isolated lightest mass (usually H).

During the fitting of NCP to each spectra, store the FSE corrections on workspaces.
During the data processing part before focusing data for y sapce fit, use the stored fse on the workspaces and subtract only the fse for the first mass from the isolated first mass for all spectra (before doing the weighted average).

It's not necessary to subtract the FSE for the other masses because this is done already when we subtract the ncp fits (since strictly speaknig the ncp fits include the FSE corrections i.e. NCP+FSE)

**To test:**

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #xxxx.
