### PR TITLE
Improve numerical third derivative

### DIFF
--- a/src/mvesuvio/analysis_reduction.py
+++ b/src/mvesuvio/analysis_reduction.py
@@ -12,7 +12,7 @@ from mantid.simpleapi import mtd, CreateEmptyTableWorkspace, SumSpectra, \
                             VesuvioThickness, Integration, Divide, Multiply, DeleteWorkspaces, \
                             CreateWorkspace, CreateSampleWorkspace
 
-from mvesuvio.util.analysis_helpers import loadConstants, numericalThirdDerivative, extend_range_of_array
+from mvesuvio.util.analysis_helpers import loadConstants, numerical_third_derivativ, extend_range_of_array
 
 
 
@@ -667,7 +667,7 @@ class VesuvioAnalysisRoutine(PythonAlgorithm):
         JOfY = scipy.special.voigt_profile(y_space_arrays_extended - centers, totalGaussWidth, lorzRes)
 
         FSE = (
-            -numericalThirdDerivative(y_space_arrays_extended, JOfY)
+            -numerical_third_derivative(y_space_arrays_extended, JOfY)
             * widths**4
             / deltaQ
             * 0.72

--- a/src/mvesuvio/util/analysis_helpers.py
+++ b/src/mvesuvio/util/analysis_helpers.py
@@ -249,6 +249,12 @@ def loadConstants():
     return constants
 
 
+def extend_range_of_array(arr, n_columns):
+    left_extend = arr[:, :n_columns] + (arr[:, 0] - arr[:, n_columns]).reshape(-1, 1)
+    right_extend = arr[:, -n_columns:] + (arr[:, -1] - arr[:, -n_columns-1]).reshape(-1, 1)
+    return np.concatenate([left_extend, arr, right_extend], axis=-1)
+
+
 def numericalThirdDerivative(x, y):
     k6 = (- y[:, 12:] + y[:, :-12]) * 1
     k5 = (+ y[:, 11:-1] - y[:, 1:-11]) * 24

--- a/src/mvesuvio/util/analysis_helpers.py
+++ b/src/mvesuvio/util/analysis_helpers.py
@@ -257,13 +257,9 @@ def numericalThirdDerivative(x, y):
     k2 = (+ y[:, 8:-4] - y[:, 4:-8]) * 387
     k1 = (- y[:, 7:-5] + y[:, 5:-7]) * 1584
 
-    dev = k1 + k2 + k3 + k4 + k5 + k6
-    dev /= np.power(x[:, 7:-5] - x[:, 6:-6], 3)
-    dev /= 12**3
-
-    derivative = np.zeros_like(y)
-    # Padded with zeros left and right to return array with same shape
-    derivative[:, 6:-6] = dev
+    derivative = k1 + k2 + k3 + k4 + k5 + k6
+    derivative /= np.power(x[:, 7:-5] - x[:, 6:-6], 3)
+    derivative /= 12**3
     return derivative
 
 

--- a/src/mvesuvio/util/analysis_helpers.py
+++ b/src/mvesuvio/util/analysis_helpers.py
@@ -255,7 +255,7 @@ def extend_range_of_array(arr, n_columns):
     return np.concatenate([left_extend, arr, right_extend], axis=-1)
 
 
-def numericalThirdDerivative(x, y):
+def numerical_third_derivative(x, y):
     k6 = (- y[:, 12:] + y[:, :-12]) * 1
     k5 = (+ y[:, 11:-1] - y[:, 1:-11]) * 24
     k4 = (- y[:, 10:-2] + y[:, 2:-10]) * 192

--- a/tests/unit/analysis/test_analysis_helpers.py
+++ b/tests/unit/analysis/test_analysis_helpers.py
@@ -1,11 +1,13 @@
 import unittest
 import numpy as np
+import scipy
 import dill
 import numpy.testing as nptest
 from mock import MagicMock
 from mvesuvio.util.analysis_helpers import extractWS, _convert_dict_to_table,  \
-    fix_profile_parameters, calculate_h_ratio, numericalThirdDerivative, extend_range_of_array
+    fix_profile_parameters, calculate_h_ratio, numerical_third_derivative, extend_range_of_array
 from mantid.simpleapi import CreateWorkspace, DeleteWorkspace
+import matplotlib.pyplot as plt
 
 
 class TestAnalysisHelpers(unittest.TestCase):
@@ -138,6 +140,16 @@ class TestAnalysisHelpers(unittest.TestCase):
         x = np.vstack([x, 2*x])
         x_extended = extend_range_of_array(x, 5)
         np.testing.assert_array_equal(x_extended, np.vstack([np.linspace(-7.5, 7.5, 31), np.linspace(-15, 15, 31)]))
+
+
+    def test_numerical_third_derivative(self):
+        x= np.linspace(-20, 20, 300)    # Workspaces are about 300 points of range
+        x = np.vstack([x, 2*x])
+        y = scipy.special.voigt_profile(x, 5, 5)
+        numerical_derivative = numerical_third_derivative(x, y)
+        expected_derivative = np.array([np.gradient(np.gradient(np.gradient(y_i, x_i), x_i), x_i)[6: -6] for y_i, x_i in zip(y, x) ])
+        np.testing.assert_allclose(numerical_derivative, expected_derivative, atol=1e-6)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/analysis/test_analysis_helpers.py
+++ b/tests/unit/analysis/test_analysis_helpers.py
@@ -4,7 +4,7 @@ import dill
 import numpy.testing as nptest
 from mock import MagicMock
 from mvesuvio.util.analysis_helpers import extractWS, _convert_dict_to_table,  \
-    fix_profile_parameters, calculate_h_ratio
+    fix_profile_parameters, calculate_h_ratio, numericalThirdDerivative, extend_range_of_array
 from mantid.simpleapi import CreateWorkspace, DeleteWorkspace
 
 
@@ -125,6 +125,19 @@ class TestAnalysisHelpers(unittest.TestCase):
         self.assertEqual(converted_constraints[0]['fun']([3, 0, 0, 1]), 3-2.7527)
         self.assertEqual(converted_constraints[1]['fun']([0, 0, 0, 2, 0, 0, 1]), 2-0.7234)
 
+
+    def test_extend_range_of_array_for_increasing_range(self):
+        x = np.arange(10)
+        x = np.vstack([x, 2*x])
+        x_extended = extend_range_of_array(x, 5)
+        np.testing.assert_array_equal(x_extended, np.vstack([np.arange(-5, 15, 1), np.arange(-10, 30, 2)]))
+
+
+    def test_extend_range_of_array_for_decreasing_range(self):
+        x = np.linspace(-5, 5, 21)
+        x = np.vstack([x, 2*x])
+        x_extended = extend_range_of_array(x, 5)
+        np.testing.assert_array_equal(x_extended, np.vstack([np.linspace(-7.5, 7.5, 31), np.linspace(-15, 15, 31)]))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Description of work:**
Function for calculating the third derivative numerically used to pad edges with zeros, which is not desirable.
This slight change makes sure the edges are smooth.

**To test:**

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #xxxx.
