### PR TITLE
Delete specification of Mambaforge variant

### DIFF
--- a/.github/workflows/ci_tests_nightly.yml
+++ b/.github/workflows/ci_tests_nightly.yml
@@ -19,7 +19,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           activate-environment: mvesuvio-env
           environment-file: environment.yml
           auto-activate-base: false

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -27,10 +27,9 @@ jobs:
 
       - name: Setup Miniconda
         if: ${{ env.recentCommits == 'true'}}
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           activate-environment: vesuvio-env
           environment-file: environment.yml
           auto-activate-base: false

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -19,7 +19,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           activate-environment: vesuvio-env
           environment-file: environment.yml
           auto-activate-base: false


### PR DESCRIPTION
**Description of work:**
Since Mambaforge got replaced by Miniforge (https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/), I am removing the specification of the Mambaforge variant from the code.

**To test:**
Check that test for setting up Miniforge passes.

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->

