### PR TITLE
Overwrite analysis inputs file

### DIFF
--- a/src/mvesuvio/util/handle_config.py
+++ b/src/mvesuvio/util/handle_config.py
@@ -91,7 +91,7 @@ def setup_config_dir(config_dir):
 
 
 def setup_default_inputs():
-    _ = copyfile(
+    copyfile(
             os.path.join(VESUVIO_PACKAGE_PATH, "config", VESUVIO_INPUTS_FILE),
             os.path.join(VESUVIO_INPUTS_PATH),
         )

--- a/src/mvesuvio/util/handle_config.py
+++ b/src/mvesuvio/util/handle_config.py
@@ -91,8 +91,7 @@ def setup_config_dir(config_dir):
 
 
 def setup_default_inputs():
-    if not os.path.isfile(VESUVIO_INPUTS_PATH):
-        copyfile(
+    _ = copyfile(
             os.path.join(VESUVIO_PACKAGE_PATH, "config", VESUVIO_INPUTS_FILE),
             os.path.join(VESUVIO_INPUTS_PATH),
         )
@@ -107,15 +106,13 @@ def setup_default_ipfile_dir():
         )
 
 
-def __mk_dir(type, path):
-    success = False
-    if not os.path.isdir(path):
-        try:
-            os.makedirs(path)
-            success = True
-        except:
-            print(f"Unable to make {type} directory at location: {path}")
-    return success
+def __mk_dir(type:str, path: str):
+    try:
+        os.makedirs(path, exist_ok=True)
+        return True
+    except:
+        print(f"Unable to make {type} directory at location: {path}")
+        return False 
 
 
 def config_set():

--- a/tests/unit/analysis/test_handle_config.py
+++ b/tests/unit/analysis/test_handle_config.py
@@ -1,0 +1,41 @@
+import unittest
+from mock import MagicMock, patch, call
+from mvesuvio.util import handle_config
+import tempfile
+import os
+
+class TestHandleConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    def test_setup_default_inputs(self):
+        tempdir = tempfile.gettempdir()
+        mock_path = os.path.join(tempdir, 'mock_inputs.py')
+        # Make sure file does not exist from previous tests
+        try:
+            os.remove(mock_path)
+        except FileNotFoundError:
+            pass
+
+        with patch.object(handle_config, "VESUVIO_INPUTS_PATH", mock_path):
+
+            handle_config.setup_default_inputs()
+
+            file = open(mock_path, 'r')
+            original_content = file.read()
+            file.close()
+
+            file = open(mock_path, 'w+')
+            file.write('Overwrite file!')
+            file.seek(0)
+            # Check that file was overwritten
+            self.assertEqual("Overwrite file!", file.read())
+            file.close()
+
+            handle_config.setup_default_inputs()
+
+            file = open(mock_path, 'r')
+            self.assertEqual(original_content, file.read())
+            file.close()
+            os.remove(mock_path)

--- a/tests/unit/analysis/test_run_routine.py
+++ b/tests/unit/analysis/test_run_routine.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import mvesuvio
 import tempfile
 from textwrap import dedent
+import os
 
 class TestRunRoutine(unittest.TestCase):
     @classmethod
@@ -66,5 +67,7 @@ class TestRunRoutine(unittest.TestCase):
             2025-01-08 10:48:49,391 [0] Notice Python - 
             Unshared Parameters: ['A', 'x0']
                          """).encode(), current_log_file_content)
+        os.remove(mock_mantid_log_file.name)
+        os.remove(mock_log_file.name)
 
 


### PR DESCRIPTION
**Description of work:**
This change improves the quality of life of scientists because in order to update their analysis inputs file following an update they no longer need to delete their entire config folder.

Running `vesuvio config` will now update the `analysis_inputs.py` file, even if the config folder `./mvesuvio` already exists.

**To test:**
  - Checkout this branch and create the development environment by running `mamba env create -f vesuvio-dev.yml`
  - `mamba activate vesuvio-dev`
  - Install the vesuvio package by running `pip install -e  .` (the only reason I use pip here is because it's faster than mamba build)
  - Run `mvesuvio config`
  - Open file `~/.mvesuvio/analysis_inputs.py` and write anything to it (changes will be overwritten)
  - Run `mvesuvio config`
  - Open file `~/.mvesuvio/analysis_inputs.py` and check that your changes were overwritten
  - Delete `~/.mvesuvio/`
  - Run `mvesuvio config`
  - Check that a new folder `~/.mvesuvio` was created
  
<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #156 .
