### PR TITLE
Split yspace inputs in backward and forward

### DIFF
--- a/src/mvesuvio/config/analysis_inputs.py
+++ b/src/mvesuvio/config/analysis_inputs.py
@@ -11,8 +11,8 @@ class SampleParameters:
 
 @dataclass
 class BackwardAnalysisInputs(SampleParameters):
-    run_this_scattering_type = False
-    fit_in_y_space = False
+    run_this_scattering_type = True
+    fit_in_y_space = True
 
     runs = "43066-43076"
     empty_runs = "41876-41923" 
@@ -43,6 +43,29 @@ class BackwardAnalysisInputs(SampleParameters):
     multiple_scattering_order = 2
     multiple_scattering_number_of_events = 1.0e5
     do_gamma_correction = False
+
+
+    show_plots = True
+    do_symmetrisation = False
+    subtract_calculated_fse_from_data = True
+    range_for_rebinning_in_y_space = "-25, 0.5, 25"  # Needs to be symetric
+    # Fitting model options
+    # 'gauss': Single Gaussian
+    # 'gcc4': Gram-Charlier with C4 parameter
+    # 'gcc6': Gram-Charlier with C6 parameter
+    # 'doublewell': Double Well function 
+    # 'gauss3D': 3-Dimensional Gaussian 
+    fitting_model = "gauss"
+    run_minos = True
+    do_global_fit = True   # Performs global fit with Minuit by default
+    # Number of groups of detectors to perform global (simultaneous) fit on
+    # Either an integer less than the number of detectors 
+    # or option 'all', which does not form groups and fits all spectra simultaneously and individualy 
+    number_of_global_fit_groups = 4
+    # Type of masking 
+    # 'nan': Zeros in workspace being fit are ignored
+    # 'ncp': Zeros in workspace being fit are replaced by the fitted neutron compton profile 
+    mask_zeros_with = "nan"   
 
 
 @dataclass
@@ -81,8 +104,6 @@ class ForwardAnalysisInputs(SampleParameters):
     do_gamma_correction = True
 
 
-@dataclass
-class YSpaceFitInputs:
     show_plots = True
     do_symmetrisation = False
     subtract_calculated_fse_from_data = True

--- a/src/mvesuvio/config/analysis_inputs.py
+++ b/src/mvesuvio/config/analysis_inputs.py
@@ -44,7 +44,6 @@ class BackwardAnalysisInputs(SampleParameters):
     multiple_scattering_number_of_events = 1.0e5
     do_gamma_correction = False
 
-
     show_plots = True
     do_symmetrisation = False
     subtract_calculated_fse_from_data = True
@@ -102,7 +101,6 @@ class ForwardAnalysisInputs(SampleParameters):
     multiple_scattering_order = 2
     multiple_scattering_number_of_events = 1.0e5
     do_gamma_correction = True
-
 
     show_plots = True
     do_symmetrisation = False

--- a/src/mvesuvio/main/run_routine.py
+++ b/src/mvesuvio/main/run_routine.py
@@ -32,7 +32,6 @@ class Runner:
 
         self.bckwd_ai = ai.BackwardAnalysisInputs
         self.fwd_ai = ai.ForwardAnalysisInputs
-        self.yFitIC = ai.YSpaceFitInputs
 
         # Names of workspaces to check if they exist to skip analysis
         self.ws_to_fit_y_space = []
@@ -63,7 +62,8 @@ class Runner:
         # TODO: sort out yfit inputs
         figSavePath = self.experiment_path / "figures"
         figSavePath.mkdir(exist_ok=True)
-        self.yFitIC.figSavePath = figSavePath
+        self.fwd_ai.figSavePath = figSavePath
+        self.bckwd_ai.figSavePath = figSavePath
 
 
     def import_from_inputs(self):
@@ -95,7 +95,7 @@ class Runner:
 
     def runAnalysisFitting(self):
         for wsName, i_cls in zip(self.ws_to_fit_y_space, self.classes_to_fit_y_space):
-            self.fitting_result = fitInYSpaceProcedure(self.yFitIC, i_cls, wsName)
+            self.fitting_result = fitInYSpaceProcedure(i_cls, wsName)
         return
 
 

--- a/tests/data/analysis/inputs/analysis_test.py
+++ b/tests/data/analysis/inputs/analysis_test.py
@@ -42,6 +42,17 @@ class BackwardAnalysisInputs(SampleParameters):
     do_gamma_correction = False
 
 
+    show_plots = False
+    do_symmetrisation = True
+    subtract_calculated_fse_from_data = False
+    range_for_rebinning_in_y_space = "-20, 0.5, 20"  # Needs to be symetric
+    fitting_model = "SINGLE_GAUSSIAN"
+    run_minos = True
+    do_global_fit = None
+    number_of_global_fit_groups = 4
+    mask_zeros_with = None
+
+
 class ForwardAnalysisInputs(SampleParameters):
     run_this_scattering_type = True
     fit_in_y_space = False
@@ -82,7 +93,6 @@ class ForwardAnalysisInputs(SampleParameters):
     do_gamma_correction= True
 
 
-class YSpaceFitInputs:
     show_plots = False
     do_symmetrisation = True
     subtract_calculated_fse_from_data = False

--- a/tests/data/analysis/inputs/yspace_gauss_test.py
+++ b/tests/data/analysis/inputs/yspace_gauss_test.py
@@ -1,13 +1,13 @@
 from tests.data.analysis.inputs.analysis_test import (
     BackwardAnalysisInputs,
     ForwardAnalysisInputs,
-    YSpaceFitInputs,
 )
 ForwardAnalysisInputs.fit_in_y_space = True 
 BackwardAnalysisInputs.fit_in_y_space = False
 ForwardAnalysisInputs.run_this_scattering_type = True 
 BackwardAnalysisInputs.run_this_scattering_type = False
-YSpaceFitInputs.fitting_model = "gauss"
+ForwardAnalysisInputs.fitting_model = "gauss"
+BackwardAnalysisInputs.fitting_model = "gauss"
 
 if (__name__ == "__main__") or (__name__ == "mantidqt.widgets.codeeditor.execution"):
     import mvesuvio

--- a/tests/data/analysis/inputs/yspace_gc_test.py
+++ b/tests/data/analysis/inputs/yspace_gc_test.py
@@ -1,15 +1,16 @@
 from tests.data.analysis.inputs.analysis_test import (
     BackwardAnalysisInputs,
     ForwardAnalysisInputs,
-    YSpaceFitInputs,
 )
 
 ForwardAnalysisInputs.fit_in_y_space = True 
 BackwardAnalysisInputs.fit_in_y_space = False
 ForwardAnalysisInputs.run_this_scattering_type = True 
 BackwardAnalysisInputs.run_this_scattering_type = False
-YSpaceFitInputs.fitting_model = "gcc4c6"
-YSpaceFitInputs.do_symmetrisation = False 
+ForwardAnalysisInputs.fitting_model = "gcc4c6"
+ForwardAnalysisInputs.do_symmetrisation = False 
+BackwardAnalysisInputs.fitting_model = "gcc4c6"
+BackwardAnalysisInputs.do_symmetrisation = False 
 
 
 if (__name__ == "__main__") or (__name__ == "mantidqt.widgets.codeeditor.execution"):


### PR DESCRIPTION
**Description of work:**
Anna requested that due to new requirements, the fit in y-space routine needs to be run for both backward and forward routines, but with different inputs. Easiest way to achieve this is to split the y-space inputs into the two classes of analysis inputs for both forward and backward.

**To test:**
Create and sctivate a test environment with mantidworkbench installed:
  - Checkout this branch and install with `pip install -e  .`
  - Run `mvesuvio config`
  - Open Mantid workbench and open file `~/.mvesuvio/analysis_inputs.py`
  - In the class `BackwardAnalysisInputs` change the field `run_this_scattering_type = True` and in `ForwardAnalysisInputs` change `run_this_scattering_type = False`
  - Click Run and check that the script runs without errors
  - In the class `BackwardAnalysisInputs` change the field `run_this_scattering_type = False` and in `ForwardAnalysisInputs` change `run_this_scattering_type = True`
  - Click Run and check that the script runs without errors

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #xxxx.
