### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -40,6 +40,15 @@ jobs:
         run: |
           echo "calibration-changed=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q -e '^tools/calibration_scripts/' -e '^tests/' && echo true || echo false)" >> $GITHUB_ENV
 
+      - name: Check if first workflow to run on PR 
+        run: |
+          # Check if the base commit (before the PR) exists in the history
+          if ! git merge-base --is-ancestor ${{ github.event.pull_request.base.sha }} HEAD; then
+            echo "First push detected (or force push), running all tests."
+            echo "analysis-changed=true" >> $GITHUB_ENV
+            echo "calibration-changed=true" >> $GITHUB_ENV
+          fi
+
       - name: Run mvesuvio Analysis Unit Tests
         if: ${{ env.analysis-changed == 'true'}}
         run: |

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -38,6 +38,7 @@ test:
     - mock 
   source_files:
     - tests/unit/
+    - tests/data/analysis/inputs/analysis_test.py   # Not a test, used by log file unit test
     - tools/
   commands:
     - pytest


### PR DESCRIPTION
**Description of work:**
The nightly build was failing due to one file not being included in the sources for the tests when building the conda package. As a separate issue, I also added a check to make all tests run on the very first workflow run on the PR. Previously they were not running due to the checks I introduced a while ago that would only trigger the tests when comparing with the previous commit on the PR, but since the first commit would not have a previous one, the analysis and calibration tests would not be triggered.

- [x] Add inputs file to conda package (input to one of the unit tests)
- [x] Make first commit to PR run all tests (both calibration and analysis)

**To test:**
- Check that all tests (calibration and analysis) are run on the first workflow and pass

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #xxxx.
