### PR TITLE
Fix masked TOF columns in reduction

### DIFF
--- a/src/mvesuvio/analysis_reduction.py
+++ b/src/mvesuvio/analysis_reduction.py
@@ -532,9 +532,10 @@ class VesuvioAnalysisRoutine(PythonAlgorithm):
         data_e = self._dataE[self._row_being_fit]
 
         # Ignore any masked values on tof range
-        ncp_total = ncp_total[np.nonzero(data_y)]
-        data_y = data_y[np.nonzero(data_y)]
-        data_e = data_e[np.nonzero(data_y)]
+        nonzero_mask = np.nonzero(data_y)
+        ncp_total = ncp_total[nonzero_mask]
+        data_y = data_y[nonzero_mask]
+        data_e = data_e[nonzero_mask]
 
         if np.all(data_e == 0):  # When errors not present
             return np.sum((ncp_total - data_y) ** 2)

--- a/src/mvesuvio/config/analysis_inputs.py
+++ b/src/mvesuvio/config/analysis_inputs.py
@@ -11,7 +11,7 @@ class SampleParameters:
 
 @dataclass
 class BackwardAnalysisInputs(SampleParameters):
-    run_this_scattering_type = True
+    run_this_scattering_type = False
     fit_in_y_space = True
 
     runs = "43066-43076"

--- a/tests/unit/analysis/test_analysis_reduction.py
+++ b/tests/unit/analysis/test_analysis_reduction.py
@@ -141,17 +141,20 @@ class TestAnalysisReduction(unittest.TestCase):
 
         alg._dataE = np.zeros_like(alg._dataX)
         chi2_without_errors = alg._error_function(example_fit_parameters)
+        self.assertEqual(chi2_without_errors, 
+                         np.sum((alg._dataY - np.sum(NCP, axis=0))**2))
 
         alg._dataE = np.full_like(alg._dataX, 0.0015, dtype=np.double)
         chi2_with_errors = alg._error_function(example_fit_parameters)
+        self.assertEqual(chi2_with_errors, 
+                         np.sum((alg._dataY - np.sum(NCP, axis=0))**2 / alg._dataE**2))
 
-        alg._dataY[:, 5:15] = 0
+        alg._dataY[0, :20] = 0
         chi2_with_errors_with_tof_masked = alg._error_function(example_fit_parameters)
+        self.assertEqual(chi2_with_errors_with_tof_masked, 
+                         np.sum((alg._dataY[0, 20:] - np.sum(NCP, axis=0)[20:])**2 / alg._dataE[0, 20:]**2))
 
         self.assertAlmostEqual(chi2_without_errors, chi2_with_errors * 0.0015**2, places=15)
-        self.assertEqual(chi2_without_errors, 1.7627158500114776e-05)
-        self.assertEqual(chi2_with_errors, 7.834292666717679)
-        self.assertEqual(chi2_with_errors_with_tof_masked, 5.5864483595799195)
 
 
     def test_fit_neutron_compton_profiles_to_row(self):


### PR DESCRIPTION
**Description of work:**
I noticed that when columns of zeros were present the fit of the spectra were failing.
Then after some time I spotted a mistake in the calculation with the error function.
Previous unit tests were not picking this up because I had written the error into them. 
I edited the unit tests to now always expect the correct result.

**To test:**
Code review, check that all tests pass (the expected behaviour is now covered by the unit test)
