### PR TITLE
Remove pin from jacobi package

### DIFF
--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -1,5 +1,2 @@
 python:
   - 3.10
-
-jacobi:
-  - 0.4.2 #pinned until later versions are proven.

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - mantid
     - matplotlib
     - iminuit
-    - jacobi {{ jacobi }}
+    - jacobi
     - dill
 
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 # Only these few, package meant to be installed alongside vesuvio-dev.yml 
 dependencies = [
     "iminuit",
-    "jacobi==0.4.2",
+    "jacobi",
     "dill",
 ]
 


### PR DESCRIPTION

**Description of work:**
Jacobi package is actively maintained and current updates to numpy have caused an import error on the previously pinned version of the package when running on IDAaaS. Hopefully removing the pin will fix the issue.

**To test:**
Check that all tests pass.
