### PR TITLE
Save extra workspaces

### DIFF
--- a/src/mvesuvio/analysis_fitting.py
+++ b/src/mvesuvio/analysis_fitting.py
@@ -1812,7 +1812,7 @@ def plotGlobalFit(dataX, dataY, dataE, mObj, totCost, wsName, yFitIC):
 
 def save_workspaces(yFitIC):
     for ws_name in mtd.getObjectNames():
-        if ws_name.endswith('Parameters') or ws_name.endswith('Workspace'):
+        if ws_name.endswith('Parameters') or ws_name.endswith('Workspace') or ws_name.endswith('CovarianceMatrix'):
             save_path = yFitIC.save_path / f"{yFitIC.fitting_model}_fit" / ws_name
             save_path.parent.mkdir(exist_ok=True, parents=True)
             SaveAscii(ws_name, str(save_path))

--- a/src/mvesuvio/main/run_routine.py
+++ b/src/mvesuvio/main/run_routine.py
@@ -10,7 +10,7 @@ from mvesuvio.analysis_reduction import VesuvioAnalysisRoutine
 
 from mantid.api import mtd
 from mantid.api import AnalysisDataService
-from mantid.simpleapi import mtd, RenameWorkspace, Minus, SumSpectra
+from mantid.simpleapi import mtd, RenameWorkspace, SaveAscii 
 from mantid.api import AlgorithmFactory, AlgorithmManager
 
 import numpy as np
@@ -127,10 +127,13 @@ class Runner:
     def runAnalysisFitting(self):
         for wsName, i_cls in zip(self.ws_to_fit_y_space, self.classes_to_fit_y_space):
             ws_lighest_data, ws_lighest_ncp  = isolate_lighest_mass_data(mtd[wsName], mtd[wsName+"_ncp_group"], i_cls.subtract_calculated_fse_from_data) 
+            # TODO: Move resolution calculation to end of analysis, instead of beggining of fitting
             ws_resolution = calculate_resolution(min(i_cls.masses), mtd[wsName], i_cls.range_for_rebinning_in_y_space)
             # NOTE: Set saving path like this for now
             i_cls.save_path = self.experiment_path / "output_files" / "fitting"
             i_cls.save_path.mkdir(exist_ok=True, parents=True)
+            # NOTE: Resolution workspace is useful for scientists outside mantid
+            SaveAscii(ws_resolution.name(), str(i_cls.save_path))
             self.fitting_result = FitInYSpace(i_cls, ws_lighest_data, ws_lighest_ncp, ws_resolution).run()
         return
 


### PR DESCRIPTION
**Description of work:**
Anna requested that three more workspaces be saved, as per issue #168 
Also took the opportunity to tidy up the routine for estimating the Hydrogen ratio a bit, so that it's clearer for the users how to trigger it (or cancel it) and fitting is not run by default at the end of the routine.

**To test:**
- In a conda environment with mantid workbench installed, checkout this branch and do `pip install -e .` to install this version of the package
- Open workbench
- Open the following script from inside workbench: 
[analysis_inputs.zip](https://github.com/user-attachments/files/20187186/analysis_inputs.zip)

- Click Run
- A window will appear, click `Cancel`
- An error should be displayed saying the procedure was cancelled
- Click Run again
- Press Enter to start running the procedure
- Wait a few minutes until the procedure is complete, at the very end you should see that a table called `hydrogen_intensity_ratios_estimates` is printed to the console
- Now edit the script in the backward class, change `intensity_ratio_of_hydrogen_to_lowest_mass` to the number that is commented out
- Click Run and wait until its finished
- Finally, use the file explorer to check that the workspaces were saved: in `analysis_inputs/output_files/` you should see the hydrogen ratios table, in `analysis_inputs/output_files/fitting` you should see the resolution workspace and in   `analysis_inputs/output_files/fitting/gauss_fit` you should see workspaces ending in `_NormalizedCovarianceMatrix`
<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #168 
