### PR TITLE
Run y space fit in system test

### DIFF
--- a/tests/data/analysis/inputs/system_test_inputs.py
+++ b/tests/data/analysis/inputs/system_test_inputs.py
@@ -81,7 +81,7 @@ class BackwardAnalysisInputs(SampleParameters):
 @dataclass
 class ForwardAnalysisInputs(SampleParameters):
     run_this_scattering_type = True
-    fit_in_y_space = False
+    fit_in_y_space = True
 
     runs = "43066-43076"
     empty_runs = "43868-43911"


### PR DESCRIPTION
**Description of work:**
This PR performs the fit in y space in the system test for reduction to check for any errors or raised exceptions in the connection between reduction and y space. This is mostly just a basic sanity check and because the fitting in y space is negligible compared to the reduction, the running time is essentially the same.

Ideally the transition between the reduction part and the fitting will have unit tests, but for now this quick change is a good to have.

**To test:**
Check system tests pass

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #187 .
