### PR TITLE
Hide vesuvio properties file

### DIFF
--- a/src/mvesuvio/main/__init__.py
+++ b/src/mvesuvio/main/__init__.py
@@ -75,14 +75,11 @@ def __setup_config(args):
     handle_config.setup_default_inputs()
     handle_config.setup_default_ipfile_dir()
 
-    inputs = handle_config.VESUVIO_INPUTS_PATH
-    ipfolder_dir = handle_config.VESUVIO_IPFOLDER_PATH
-
-    if handle_config.config_set():
-        inputs = handle_config.read_config_var("caching.inputs")
-        ipfolder_dir = handle_config.read_config_var("caching.ipfolder")
-    else:
+    if not handle_config.config_set():
         handle_config.set_default_config_vars()
+
+    inputs = handle_config.read_config_var("caching.inputs")
+    ipfolder_dir = handle_config.read_config_var("caching.ipfolder")
 
     if args and args.set_inputs:
         inputs = str(Path(args.set_inputs).absolute())

--- a/src/mvesuvio/util/handle_config.py
+++ b/src/mvesuvio/util/handle_config.py
@@ -3,23 +3,22 @@ from shutil import copyfile, copytree, ignore_patterns
 
 
 ### PATH CONSTANTS ###
-VESUVIO_CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".mvesuvio")
-VESUVIO_CONFIG_FILE = "vesuvio.user.properties"
-VESUVIO_INPUTS_FILE = "analysis_inputs.py"
-VESUVIO_INPUTS_PATH = os.path.join(VESUVIO_CONFIG_PATH, VESUVIO_INPUTS_FILE)
 VESUVIO_PACKAGE_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+VESUVIO_CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".mvesuvio")
+VESUVIO_PROPERTIES_FILE = "vesuvio.user.properties"
+ANALYSIS_INPUTS_FILE = "analysis_inputs.py"
 MANTID_CONFIG_FILE = "Mantid.user.properties"
 PLOTS_CONFIG_FILE = "vesuvio.plots.mplstyle"
-VESUVIO_IPFOLDER_PATH = os.path.join(VESUVIO_CONFIG_PATH, "ip_files")
-SCRIPT_TO_CREATE_FIGURES = "script_to_create_figures.py"
+SCRIPT_FIGUES_FILE = "script_to_create_figures.py"
+IP_FOLDER = "ip_files"
 ######################
 
 
 def set_default_config_vars():
     set_config_vars(
         {
-            "caching.inputs": os.path.join(VESUVIO_CONFIG_PATH, VESUVIO_INPUTS_FILE),
-            "caching.ipfolder": VESUVIO_IPFOLDER_PATH,
+            "caching.inputs": os.path.join(VESUVIO_CONFIG_PATH, ANALYSIS_INPUTS_FILE),
+            "caching.ipfolder": os.path.join(VESUVIO_CONFIG_PATH, IP_FOLDER),
         }
     )
 
@@ -36,7 +35,7 @@ def __read_config(config_file_path, throw_on_not_found=True):
 
 
 def set_config_vars(var_dict):
-    file_path = os.path.join(VESUVIO_PACKAGE_PATH, "config", VESUVIO_CONFIG_FILE)
+    file_path = os.path.join(VESUVIO_PACKAGE_PATH, "config", VESUVIO_PROPERTIES_FILE)
     lines = __read_config(file_path)
 
     updated_lines = []
@@ -58,7 +57,7 @@ def set_config_vars(var_dict):
 
 
 def read_config_var(var, throw_on_not_found=True):
-    file_path = os.path.join(VESUVIO_PACKAGE_PATH, "config", VESUVIO_CONFIG_FILE)
+    file_path = os.path.join(VESUVIO_PACKAGE_PATH, "config", VESUVIO_PROPERTIES_FILE)
     lines = __read_config(file_path, throw_on_not_found)
 
     result = ""
@@ -85,8 +84,8 @@ def setup_config_dir():
     if not os.path.isdir(VESUVIO_CONFIG_PATH):
         os.makedirs(VESUVIO_CONFIG_PATH)
         copyfile(
-            os.path.join(VESUVIO_PACKAGE_PATH, "config", SCRIPT_TO_CREATE_FIGURES),
-            os.path.join(VESUVIO_CONFIG_PATH, SCRIPT_TO_CREATE_FIGURES),
+            os.path.join(VESUVIO_PACKAGE_PATH, "config", SCRIPT_FIGUES_FILE),
+            os.path.join(VESUVIO_CONFIG_PATH, SCRIPT_FIGUES_FILE),
         )
         copyfile(
             os.path.join(VESUVIO_PACKAGE_PATH, "config", PLOTS_CONFIG_FILE),
@@ -96,27 +95,18 @@ def setup_config_dir():
 
 def setup_default_inputs():
     copyfile(
-        os.path.join(VESUVIO_PACKAGE_PATH, "config", VESUVIO_INPUTS_FILE),
-        os.path.join(VESUVIO_INPUTS_PATH),
+        os.path.join(VESUVIO_PACKAGE_PATH, "config", ANALYSIS_INPUTS_FILE),
+        os.path.join(VESUVIO_CONFIG_PATH, ANALYSIS_INPUTS_FILE),
     )
 
 
 def setup_default_ipfile_dir():
-    if not os.path.isdir(VESUVIO_IPFOLDER_PATH):
+    if not os.path.isdir(os.path.join(VESUVIO_CONFIG_PATH, IP_FOLDER)):
         copytree(
             os.path.join(VESUVIO_PACKAGE_PATH, "config", "ip_files"),
-            VESUVIO_IPFOLDER_PATH,
+            os.path.join(VESUVIO_CONFIG_PATH, IP_FOLDER),
             ignore=ignore_patterns("__*"),
         )
-
-
-def __mk_dir(type: str, path: str):
-    try:
-        os.makedirs(path, exist_ok=False)
-        return True
-    except (FileNotFoundError, FileExistsError):
-        print(f"Unable to make {type} directory at location: {path}")
-        return False
 
 
 def config_set():

--- a/tests/system/analysis/test_fitting.py
+++ b/tests/system/analysis/test_fitting.py
@@ -34,7 +34,7 @@ class TestFitting(unittest.TestCase):
         cls.ws_to_fit_ncp_path = cls.inputs_path / "system_test_inputs_fwd_1_1.0079_ncp_-fse.nxs"
         cls.ws_resolution_path = cls.inputs_path / "system_test_inputs_fwd_1_resolution.nxs"
 
-        cls.ipfile_path = Path(handle_config.VESUVIO_IPFOLDER_PATH) / "ip2018_3.par"
+        cls.ipfile_path = Path(handle_config.VESUVIO_CONFIG_PATH) / handle_config.IP_FOLDER / "ip2018_3.par"
 
         return
 


### PR DESCRIPTION
**Description of work:**
Previously the state of the inputs and ip folder variables were being kept in a cache file `~/.mvesuvio/vesuvio.user.properties`. However this meant that different packages or differnt versions of mvesuvio were sharing the same file.
Since the scientists run workspaces on IDAaaS in parallel, several routines might be active at any time (from different packages) and the outputs paths were being messed up due to the file being shared amongst them.

this work puts the properties file inside the package without needing to copy it to the `.mvesuvio` folder. this means that users can't edit it (which is good) and each package will use its own version of the file, solving the issue on IDAaaS.

**To test:**
- Activate a conda environment with mantidworkbench installed
- Checkout this branch and run `pip install -e .`
- Run `vesuvio config`
- Run `vesuvio config -i /some/random/path`
- Run `vesuvio config` and check inputs path was set to `some/random/path`
- Delete the folder `~/.mvesuvio`
- Run `vesuvio config` and check that inputs path is still set to `some/random/path`
- Open the file `/path/to/vesuvio/branch/src/vesuvio/config/analysis_inputs.py` in Mantid
- Run the script and check it runs without errors (should take 1 or 2 minutes)

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #xxxx.
